### PR TITLE
Add a changelog to keep track of version differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 2.0.4 (unreleased)
+
+## Breaking changes
+
+## New features
+- [Add support for statsd metrics][0]
+- [Add support for multiple imports of rules via recursive import][0]
+
+## Other changes
+
+[0]: https://github.com/jertel/elastalert2/pull/83


### PR DESCRIPTION
I thought this might be useful to keep track of changes over time.
I am happy to maintain it, but ideally we could encourage PR authors
to add their changes as they go.

This might also be useful to get an idea of the appropriate version
change, depending on the significance of the included changes.