### PR TITLE
ES Version revert to 7.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.4.4
 cffi>=1.11.5
 configparser>=3.5.0
 croniter>=0.3.16
-elasticsearch>=7.0.0,<8.0.0
+elasticsearch==7.0.0
 envparse>=0.2.0
 exotel>=0.1.3
 Jinja2==2.11.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'boto3>=1.4.4',
         'configparser>=3.5.0',
         'croniter>=0.3.16',
-        'elasticsearch>=7.0.0,<8.0.0',
+        'elasticsearch==7.0.0',
         'envparse>=0.2.0',
         'exotel>=0.1.3',
         'jira>=2.0.0',


### PR DESCRIPTION
As noted in https://github.com/Yelp/elastalert/issues/2725 more recent versions of elasticsearch pip package causes errors.  Started seeing these errors when moving to the newest release here.

Error:
```
deprecated_search() got an unexpected keyword argument 'headers'
```

I see this was updated in https://github.com/jertel/elastalert2/commit/45237cc364e2cafc1859d12841b1bab11c810d9f however from my experience it probably needs to be reverted for now.

~~Also a slight change to the Dockerfile.  If someones already cloned the repo, in order to work on the Dockerfile, having it RUN git clone again is confusing.~~