### PR TITLE
Update schema.yaml and ruletypes.rst

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1910,6 +1910,18 @@ by the smtp server.
 ``email_format``: If set to 'html', the email's MIME type will be set to HTML, and HTML content should correctly render. If you use this,
 you need to put your own HTML into ``alert_text`` and use ``alert_text_type: alert_text_jinja`` Or ``alert_text_type: alert_text_only``.
 
+``assets_dir``: images dir. default to ``/tmp``.
+
+``email_image_keys``: mapping between images keys.
+
+``email_image_values``: mapping between images values
+
+Example assets_dir, email_image_keys, email_image_values::
+
+	assets_dir: "/opt/elastalert/email_images"
+	email_image_keys: ["img1"]
+	email_image_values: ["my_logo.png"]
+
 Exotel
 ~~~~~~
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -330,6 +330,9 @@ properties:
   cc: *arrayOfString
   bcc: *arrayOfString
   email_format: {type: string}
+  assets_dir: {type: string}
+  email_image_keys: {type: array, items: {type: string}}
+  email_image_values: {type: array, items: {type: string}}
   notify_email: *arrayOfString # if rule is slow or erroring, send to this email
 
   ### Exotel
@@ -344,7 +347,7 @@ properties:
   gitter_proxy: {type: string}
 
   ### GoogleChat
-  googlechat_webhook_url: {type: string}
+  googlechat_webhook_url: *arrayOfString
   googlechat_format: {type: string, enum: ['basic', 'card']}
   googlechat_header_title: {type: string}
   googlechat_header_subtitle: {type: string}
@@ -352,7 +355,7 @@ properties:
   googlechat_footer_kibanalink: {type: string}
 
   ### HTTP POST
-  http_post_url: {type: string}
+  http_post_url: *arrayOfString
   http_post_proxy: {type: string}
   http_post_ca_certs: {type: boolean}
   http_post_ignore_ssl_errors: {type: boolean}
@@ -403,7 +406,7 @@ properties:
   mattermost_author_icon: {type: string}
 
   ### Microsoft Teams
-  ms_teams_webhook_url: {type: string}
+  ms_teams_webhook_url: *arrayOfString
   ms_teams_alert_summary: {type: string}
   ms_teams_theme_color: {type: string}
   ms_teams_proxy: {type: string}


### PR DESCRIPTION
I'm sorry. In the previous pull request, there were 3 mistakes in updating schema.yaml and additional omissions. Added email item to ruletypes.rst.

**schema.yaml**

- add
  - assets_dir: {type: string}
  - email_image_keys: {type: array, items: {type: string}}
  - email_image_values: {type: array, items: {type: string}}
- modify
  - ms_teams_webhook_url: {type: string} → ms_teams_webhook_url: *arrayOfString
  - http_post_url: {type: string}} → http_post_url: *arrayOfString
  - googlechat_webhook_url: {type: string}→ googlechat_webhook_url: *arrayOfString

**ruletypes.rst**

 - Email
   - assets_dir
   - email_image_keys
   - email_image_values