### PR TITLE
Begin alerter refactoring and migration

### DIFF
--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -3,11 +3,11 @@ import json
 import os.path
 import requests
 
-from .alerts import Alerter
-from .alerts import BasicMatchString
-from .util import EAException
-from .util import elastalert_logger
-from .util import lookup_es_key
+from ..alerts import Alerter
+from ..alerts import BasicMatchString
+from ..util import EAException
+from ..util import elastalert_logger
+from ..util import lookup_es_key
 
 
 class OpsGenieAlerter(Alerter):

--- a/elastalert/alerters/zabbix.py
+++ b/elastalert/alerters/zabbix.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 from pyzabbix import ZabbixSender, ZabbixMetric, ZabbixAPI
 
-from .alerts import Alerter
-from .util import elastalert_logger, EAException
+from ..alerts import Alerter
+from ..util import elastalert_logger, EAException
 
 
 class ZabbixClient(ZabbixAPI):

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -15,7 +15,8 @@ from jinja2 import FileSystemLoader
 from . import alerts
 from . import enhancements
 from . import ruletypes
-from .opsgenie import OpsGenieAlerter
+from .alerters.opsgenie import OpsGenieAlerter
+from .alerters.zabbix import ZabbixAlerter
 from .util import dt_to_ts
 from .util import dt_to_ts_with_format
 from .util import dt_to_unix
@@ -27,7 +28,6 @@ from .util import ts_to_dt
 from .util import ts_to_dt_with_format
 from .util import unix_to_dt
 from .util import unixms_to_dt
-from .zabbix import ZabbixAlerter
 from .yaml import read_yaml
 
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -36,7 +36,8 @@ from elastalert.alerts import ServiceNowAlerter
 from elastalert.alerts import SlackAlerter
 from elastalert.alerts import TelegramAlerter
 from elastalert.loaders import FileRulesLoader
-from elastalert.opsgenie import OpsGenieAlerter
+from elastalert.alerters.opsgenie import OpsGenieAlerter
+from elastalert.alerters.zabbix import ZabbixAlerter
 from elastalert.alerts import VictorOpsAlerter
 from elastalert.util import ts_add
 from elastalert.util import ts_now
@@ -7156,3 +7157,33 @@ def test_thehive_alerter():
     del actual_data['sourceRef']
 
     assert expected_data == actual_data
+
+
+def test_zabbix_basic():
+    rule = {
+        'name': 'Basic Zabbix test',
+        'type': 'any',
+        'alert_text_type': 'alert_text_only',
+        'alert': [],
+        'alert_subject': 'Test Zabbix',
+        'zbx_host': 'example.com',
+        'zbx_key': 'example-key'
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = ZabbixAlerter(rule)
+    match = {
+        '@timestamp': '2021-01-01T00:00:00Z',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('pyzabbix.ZabbixSender.send') as mock_zbx_send:
+        alert.alert([match])
+
+        zabbix_metrics = {
+            "host": "example.com",
+            "key": "example-key",
+            "value": "1",
+            "clock": 1609459200
+        }
+        alerter_args = mock_zbx_send.call_args.args
+        assert vars(alerter_args[0][0]) == zabbix_metrics


### PR DESCRIPTION
- Create a new alerters folder
- Move the Zabbix and OpsGenie alerters to the folder
- Refactor to load the alerters from the folder
- Add a new test for the Zabbix alerter

Once this is merged (and if we are happy with this format for the migration),
I will do all the other alerters.