### PR TITLE
Switch to absolute imports

### DIFF
--- a/elastalert/alerters/email.py
+++ b/elastalert/alerters/email.py
@@ -1,9 +1,7 @@
 import os
 
-from ..alerts import Alerter
-from ..util import elastalert_logger
-from ..util import lookup_es_key
-from ..util import EAException
+from elastalert.alerts import Alerter
+from elastalert.util import elastalert_logger, lookup_es_key, EAException
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.image import MIMEImage

--- a/elastalert/alerters/jira.py
+++ b/elastalert/alerters/jira.py
@@ -1,14 +1,14 @@
 import datetime
 import sys
 
-from ..alerts import Alerter
-from ..alerts import BasicMatchString
-from ..util import elastalert_logger
-from ..util import lookup_es_key
-from ..util import pretty_ts
-from ..util import ts_now
-from ..util import ts_to_dt
-from ..util import EAException
+from elastalert.alerts import Alerter
+from elastalert.alerts import BasicMatchString
+from elastalert.util import elastalert_logger
+from elastalert.util import lookup_es_key
+from elastalert.util import pretty_ts
+from elastalert.util import ts_now
+from elastalert.util import ts_to_dt
+from elastalert.util import EAException
 from jira.client import JIRA
 from jira.exceptions import JIRAError
 

--- a/elastalert/alerters/jira.py
+++ b/elastalert/alerters/jira.py
@@ -3,12 +3,8 @@ import sys
 
 from elastalert.alerts import Alerter
 from elastalert.alerts import BasicMatchString
-from elastalert.util import elastalert_logger
-from elastalert.util import lookup_es_key
-from elastalert.util import pretty_ts
-from elastalert.util import ts_now
-from elastalert.util import ts_to_dt
-from elastalert.util import EAException
+from elastalert.util import (elastalert_logger, lookup_es_key, pretty_ts, ts_now,
+                             ts_to_dt, EAException)
 from jira.client import JIRA
 from jira.exceptions import JIRAError
 

--- a/elastalert/alerters/mattermost.py
+++ b/elastalert/alerters/mattermost.py
@@ -3,11 +3,8 @@ import json
 import requests
 import warnings
 
-from ..alerts import Alerter
-from ..alerts import DateTimeEncoder
-from ..util import elastalert_logger
-from ..util import lookup_es_key
-from ..util import EAException
+from elastalert.alerts import Alerter, DateTimeEncoder
+from elastalert.util import elastalert_logger, lookup_es_key, EAException
 from requests import RequestException
 
 

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -3,11 +3,8 @@ import json
 import os.path
 import requests
 
-from ..alerts import Alerter
-from ..alerts import BasicMatchString
-from ..util import EAException
-from ..util import elastalert_logger
-from ..util import lookup_es_key
+from elastalert.alerts import Alerter, BasicMatchString
+from elastalert.util import EAException, elastalert_logger, lookup_es_key
 
 
 class OpsGenieAlerter(Alerter):

--- a/elastalert/alerters/rocketchat.py
+++ b/elastalert/alerters/rocketchat.py
@@ -5,10 +5,8 @@ import requests
 from requests.exceptions import RequestException
 import warnings
 
-from ..alerts import Alerter, DateTimeEncoder
-from ..util import EAException
-from ..util import elastalert_logger
-from ..util import lookup_es_key
+from elastalert.alerts import Alerter, DateTimeEncoder
+from elastalert.util import EAException, elastalert_logger, lookup_es_key
 
 
 class RocketChatAlerter(Alerter):

--- a/elastalert/alerters/slack.py
+++ b/elastalert/alerters/slack.py
@@ -3,11 +3,8 @@ import json
 import requests
 import warnings
 
-from ..alerts import Alerter
-from ..alerts import DateTimeEncoder
-from ..util import elastalert_logger
-from ..util import lookup_es_key
-from ..util import EAException
+from elastalert.alerts import Alerter, DateTimeEncoder
+from elastalert.util import elastalert_logger, EAException, lookup_es_key
 from requests.exceptions import RequestException
 
 

--- a/elastalert/alerters/sns.py
+++ b/elastalert/alerters/sns.py
@@ -1,7 +1,7 @@
 import boto3
 
-from ..alerts import Alerter
-from ..util import elastalert_logger
+from elastalert.alerts import Alerter
+from elastalert.util import elastalert_logger
 
 
 class SnsAlerter(Alerter):

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -1,10 +1,8 @@
 import json
 import requests
 
-from ..alerts import Alerter
-from ..alerts import DateTimeEncoder
-from ..util import EAException
-from ..util import elastalert_logger
+from elastalert.alerts import Alerter, DateTimeEncoder
+from elastalert.util import EAException, elastalert_logger
 from requests.exceptions import RequestException
 
 

--- a/elastalert/alerters/zabbix.py
+++ b/elastalert/alerters/zabbix.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 from pyzabbix import ZabbixSender, ZabbixMetric, ZabbixAPI
 
-from ..alerts import Alerter
-from ..util import elastalert_logger, EAException
+from elastalert.alerts import Alerter
+from elastalert.util import elastalert_logger, EAException
 
 
 class ZabbixClient(ZabbixAPI):

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -5,8 +5,7 @@ import os
 
 from texttable import Texttable
 
-from elastalert.util import EAException
-from elastalert.util import lookup_es_key
+from elastalert.util import EAException, lookup_es_key
 from elastalert.yaml import read_yaml
 
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -5,9 +5,9 @@ import os
 
 from texttable import Texttable
 
-from .util import EAException
-from .util import lookup_es_key
-from .yaml import read_yaml
+from elastalert.util import EAException
+from elastalert.util import lookup_es_key
+from elastalert.yaml import read_yaml
 
 
 class DateTimeEncoder(json.JSONEncoder):

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -5,10 +5,8 @@ import logging.config
 
 from envparse import Env
 
-from . import loaders
-from .util import EAException
-from .util import elastalert_logger
-from .util import get_module
+from elastalert import loaders
+from elastalert.util import EAException, elastalert_logger, get_module
 
 from elastalert.yaml import read_yaml
 

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -14,7 +14,7 @@ from elasticsearch.client import IndicesClient
 from elasticsearch.exceptions import NotFoundError
 from envparse import Env
 
-from .auth import Auth
+from elastalert.auth import Auth
 
 env = Env(ES_USE_SSL=bool)
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -28,36 +28,19 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.exceptions import TransportError
-from .prometheus_wrapper import PrometheusWrapper
 
-from . import kibana
+from elastalert import kibana
 from elastalert.alerters.debug import DebugAlerter
-from .config import load_conf
-from .enhancements import DropMatchException
-from .kibana_discover import generate_kibana_discover_url
-from .ruletypes import FlatlineRule
-from .util import add_raw_postfix
-from .util import cronite_datetime_to_timestamp
-from .util import dt_to_ts
-from .util import dt_to_unix
-from .util import EAException
-from .util import elastalert_logger
-from .util import elasticsearch_client
-from .util import format_index
-from .util import lookup_es_key
-from .util import parse_deadline
-from .util import parse_duration
-from .util import pretty_ts
-from .util import replace_dots_in_field_names
-from .util import seconds
-from .util import set_es_key
-from .util import should_scrolling_continue
-from .util import total_seconds
-from .util import ts_add
-from .util import ts_now
-from .util import ts_to_dt
-from .util import unix_to_dt
-from .util import ts_utc_to_tz
+from elastalert.config import load_conf
+from elastalert.enhancements import DropMatchException
+from elastalert.kibana_discover import generate_kibana_discover_url
+from elastalert.prometheus_wrapper import PrometheusWrapper
+from elastalert.ruletypes import FlatlineRule
+from elastalert.util import (add_raw_postfix, cronite_datetime_to_timestamp, dt_to_ts, dt_to_unix, EAException,
+                             elastalert_logger, elasticsearch_client, format_index, lookup_es_key, parse_deadline,
+                             parse_duration, pretty_ts, replace_dots_in_field_names, seconds, set_es_key,
+                             should_scrolling_continue, total_seconds, ts_add, ts_now, ts_to_dt, unix_to_dt,
+                             ts_utc_to_tz)
 
 
 class ElastAlerter(object):

--- a/elastalert/enhancements.py
+++ b/elastalert/enhancements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .util import pretty_ts
+from elastalert.util import pretty_ts
 
 
 class BaseEnhancement(object):

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -34,30 +34,22 @@ import elastalert.alerters.dingtalk
 import elastalert.alerters.thehive
 import elastalert.alerters.rocketchat
 
-from . import alerts
-from . import enhancements
-from . import ruletypes
-from .alerters.email import EmailAlerter
-from .alerters.jira import JiraAlerter
-from .alerters.mattermost import MattermostAlerter
-from .alerters.opsgenie import OpsGenieAlerter
+from elastalert import alerts
+from elastalert import enhancements
+from elastalert import ruletypes
+from elastalert.alerters.email import EmailAlerter
+from elastalert.alerters.jira import JiraAlerter
+from elastalert.alerters.mattermost import MattermostAlerter
+from elastalert.alerters.opsgenie import OpsGenieAlerter
 from elastalert.alerters.pagerduty import PagerDutyAlerter
-from .alerters.teams import MsTeamsAlerter
-from .alerters.slack import SlackAlerter
-from .alerters.sns import SnsAlerter
-from .alerters.zabbix import ZabbixAlerter
-from .util import dt_to_ts
-from .util import dt_to_ts_with_format
-from .util import dt_to_unix
-from .util import dt_to_unixms
-from .util import EAException
-from .util import elastalert_logger
-from .util import get_module
-from .util import ts_to_dt
-from .util import ts_to_dt_with_format
-from .util import unix_to_dt
-from .util import unixms_to_dt
-from .yaml import read_yaml
+from elastalert.alerters.teams import MsTeamsAlerter
+from elastalert.alerters.slack import SlackAlerter
+from elastalert.alerters.sns import SnsAlerter
+from elastalert.alerters.zabbix import ZabbixAlerter
+from elastalert.util import dt_to_ts
+from elastalert.util import (dt_to_ts_with_format, dt_to_unix, dt_to_unixms, EAException, elastalert_logger, get_module,
+                             ts_to_dt, ts_to_dt_with_format, unix_to_dt, unixms_to_dt)
+from elastalert.yaml import read_yaml
 
 
 class RulesLoader(object):

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -34,9 +34,7 @@ import elastalert.alerters.dingtalk
 import elastalert.alerters.thehive
 import elastalert.alerters.rocketchat
 
-from elastalert import alerts
-from elastalert import enhancements
-from elastalert import ruletypes
+from elastalert import alerts, enhancements, ruletypes
 from elastalert.alerters.email import EmailAlerter
 from elastalert.alerters.jira import JiraAlerter
 from elastalert.alerters.mattermost import MattermostAlerter

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -5,19 +5,9 @@ import sys
 
 from sortedcontainers import SortedKeyList as sortedlist
 
-from .util import add_raw_postfix
-from .util import dt_to_ts
-from .util import EAException
-from .util import elastalert_logger
-from .util import elasticsearch_client
-from .util import format_index
-from .util import hashable
-from .util import lookup_es_key
-from .util import new_get_event_ts
-from .util import pretty_ts
-from .util import total_seconds
-from .util import ts_now
-from .util import ts_to_dt
+from elastalert.util import (add_raw_postfix, dt_to_ts, EAException, elastalert_logger, elasticsearch_client,
+                             format_index, hashable, lookup_es_key, new_get_event_ts, pretty_ts, total_seconds,
+                             ts_now, ts_to_dt)
 
 
 class RuleType(object):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -10,8 +10,8 @@ import dateutil.parser
 import pytz
 from six import string_types
 
-from . import ElasticSearchClient
-from .auth import Auth
+from elastalert import ElasticSearchClient
+from elastalert.auth import Auth
 
 logging.basicConfig()
 elastalert_logger = logging.getLogger('elastalert')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 docutils<0.17
 pytest-cov==2.12.0
 flake8
+flake8-absolute-import
 m2r2
 pluggy>=0.12.0
 pre-commit


### PR DESCRIPTION
PEP-8 recommends absolute imports (https://www.python.org/dev/peps/pep-0008/#imports)
and there's no reason for ElastAlert not to be using them. It also
helps makes the import structure clearer.

I have also added a linter to automatically check for this in the future.

Where possible I have also tidied the imports, removing uneccessary
multi-line `from` statements that import from the same file.