### PR TITLE
Encode json output before writing test data

### DIFF
--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -434,7 +434,7 @@ class MockElastAlerter(object):
                 with open(args.save, 'wb') as data_file:
                     # Add _id to _source for dump
                     [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                    data_file.write(json.dumps([doc['_source'] for doc in hits], indent=4))
+                    data_file.write(str.encode(json.dumps([doc['_source'] for doc in hits], indent=4)))
             if args.use_downloaded:
                 if hits:
                     args.json = args.save


### PR DESCRIPTION
Signed-off-by: Vincent Bisserie <vincent.bisserie@renault.com>
Running `python test_rule.py --days 1 --save-json bar.json ./rules/bar.yaml` raises the following exception :
```
Traceback (most recent call last):
  File "/home/foo/elastalert/test_rule.py", line 455, in main
    test_instance.run_rule_test()
  File "/home/foo/elastalert/test_rule.py", line 437, in run_rule_test
    data_file.write(json.dumps([doc['_source'] for doc in hits], indent=4))
TypeError: a bytes-like object is required, not 'str'
```