### PR TITLE
Fix chatwork alerter

### DIFF
--- a/elastalert/alerters/chatwork.py
+++ b/elastalert/alerters/chatwork.py
@@ -14,8 +14,8 @@ class ChatworkAlerter(Alerter):
 
     def __init__(self, rule):
         super(ChatworkAlerter, self).__init__(rule)
-        self.chatwork_apikey = self.rule.get('chatwork_apikey')
-        self.chatwork_room_id = self.rule.get('chatwork_room_id')
+        self.chatwork_apikey = self.rule['chatwork_apikey']
+        self.chatwork_room_id = self.rule['chatwork_room_id']
         self.url = 'https://api.chatwork.com/v2/rooms/%s/messages' % (self.chatwork_room_id)
         self.chatwork_proxy = self.rule.get('chatwork_proxy', None)
         self.chatwork_proxy_login = self.rule.get('chatwork_proxy_login', None)

--- a/tests/alerters/chatwork_test.py
+++ b/tests/alerters/chatwork_test.py
@@ -101,3 +101,57 @@ def test_chatwork_ea_exception():
             alert.alert([match])
     except EAException:
         assert True
+
+
+def test_chatwork_getinfo():
+    rule = {
+        'name': 'Test Chatwork Rule',
+        'type': 'any',
+        'chatwork_apikey': 'xxxx1',
+        'chatwork_room_id': 'xxxx2',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = ChatworkAlerter(rule)
+
+    expected_data = {
+        "type": "chatwork",
+        "chatwork_room_id": "xxxx2"
+    }
+    actual_data = alert.get_info()
+    assert expected_data == actual_data
+
+
+@pytest.mark.parametrize('chatwork_apikey, chatwork_room_id, expected_data', [
+    ('',      '',      True),
+    ('xxxx1', '',      True),
+    ('',      'xxxx2', True),
+    ('xxxx1', 'xxxx2',
+        {
+            "type": "chatwork",
+            "chatwork_room_id": "xxxx2"
+        }),
+])
+def test_chatwork_key_error(chatwork_apikey, chatwork_room_id, expected_data):
+    try:
+        rule = {
+            'name': 'Test Chatwork Rule',
+            'type': 'any',
+            'alert': []
+        }
+
+        if chatwork_apikey != '':
+            rule['chatwork_apikey'] = chatwork_apikey
+
+        if chatwork_room_id != '':
+            rule['chatwork_room_id'] = chatwork_room_id
+
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = ChatworkAlerter(rule)
+
+        actual_data = alert.get_info()
+        assert expected_data == actual_data
+    except KeyError:
+        assert expected_data


### PR DESCRIPTION
Fixed a bug that a key error does not occur when the required items of ChatWork Alert are not specified.