### PR TITLE
Fix zabbix alerter

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2768,9 +2768,9 @@ Zabbix will send notification to a Zabbix server. The item in the host specified
 
 Required:
 
-``zbx_sender_host``: The address where zabbix server is running.
+``zbx_sender_host``: The address where zabbix server is running, defaults to ``'localhost'``.
 
-``zbx_sender_port``: The port where zabbix server is listenning.
+``zbx_sender_port``: The port where zabbix server is listenning, defaults to ``10051``.
 
 ``zbx_host``: This field setup the host in zabbix that receives the value sent by ElastAlert 2.
 

--- a/elastalert/alerters/zabbix.py
+++ b/elastalert/alerters/zabbix.py
@@ -53,8 +53,8 @@ class ZabbixAlerter(Alerter):
 
         self.zbx_sender_host = self.rule.get('zbx_sender_host', 'localhost')
         self.zbx_sender_port = self.rule.get('zbx_sender_port', 10051)
-        self.zbx_host = self.rule.get('zbx_host')
-        self.zbx_key = self.rule.get('zbx_key')
+        self.zbx_host = self.rule['zbx_host']
+        self.zbx_key = self.rule['zbx_key']
         self.timestamp_field = self.rule.get('timestamp_field', '@timestamp')
         self.timestamp_type = self.rule.get('timestamp_type', 'iso')
         self.timestamp_strptime = self.rule.get('timestamp_strptime', '%Y-%m-%dT%H:%M:%S.%fZ')


### PR DESCRIPTION
Fixed a bug that a key error does not occur when the required items of Zabbix Alert are not specified.