### PR TITLE
change mock to build in unittest.mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Improve Gitter alerter by explicitly specifying arg names  - [#230](https://github.com/jertel/elastalert2/pull/230) - @nsano-rururu
 - Add more alerter test code coverage - [#231](https://github.com/jertel/elastalert2/pull/231) - @nsano-rururu
 - Upgrade pytest-cov from 2.12.0 to 2.12.1 - [#232](https://github.com/jertel/elastalert2/pull/232) - @nsano-rururu
+- Migrate away from external test mock dependency - [#233](https://github.com/jertel/elastalert2/pull/233) - @nsano-rururu
 
 # 2.1.0
 

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -10,7 +10,7 @@ import re
 import string
 import sys
 
-import mock
+from unittest import mock
 
 from elastalert.config import load_conf
 from elastalert.elastalert import ElastAlerter

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ exotel>=0.1.3
 Jinja2==2.11.3
 jira>=2.0.0
 jsonschema>=3.0.2
-mock>=2.0.0
 prison>=0.1.2
 prometheus_client>=0.10.1
 py-zabbix>=1.1.3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'jira>=2.0.0',
         'Jinja2==2.11.3',
         'jsonschema>=3.0.2',
-        'mock>=2.0.0',
         'prison>=0.1.2',
         'prometheus_client>=0.10.1',
         'py-zabbix>=1.1.3',

--- a/tests/alerters/alerta_test.py
+++ b/tests/alerters/alerta_test.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/chatwork_test.py
+++ b/tests/alerters/chatwork_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 from requests.auth import HTTPProxyAuth

--- a/tests/alerters/command_test.py
+++ b/tests/alerters/command_test.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 
-import mock
+from unittest import mock
 import pytest
 
 from elastalert.alerters.command import CommandAlerter

--- a/tests/alerters/datadog_test.py
+++ b/tests/alerters/datadog_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/dingtalk_test.py
+++ b/tests/alerters/dingtalk_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 from requests.auth import HTTPProxyAuth

--- a/tests/alerters/discord_test.py
+++ b/tests/alerters/discord_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 from requests.auth import HTTPProxyAuth

--- a/tests/alerters/email_test.py
+++ b/tests/alerters/email_test.py
@@ -1,6 +1,6 @@
 import base64
 
-import mock
+from unittest import mock
 import pytest
 
 from elastalert.alerters.email import EmailAlerter

--- a/tests/alerters/gitter_test.py
+++ b/tests/alerters/gitter_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/googlechat_test.py
+++ b/tests/alerters/googlechat_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/httppost_test.py
+++ b/tests/alerters/httppost_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/jira_test.py
+++ b/tests/alerters/jira_test.py
@@ -1,6 +1,6 @@
 import datetime
 
-import mock
+from unittest import mock
 import pytest
 from jira import JIRAError
 

--- a/tests/alerters/line_test.py
+++ b/tests/alerters/line_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/mattermost_test.py
+++ b/tests/alerters/mattermost_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/pagerduty_test.py
+++ b/tests/alerters/pagerduty_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/pagertree_test.py
+++ b/tests/alerters/pagertree_test.py
@@ -2,7 +2,7 @@ import json
 import re
 import uuid
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/rocketchat_test.py
+++ b/tests/alerters/rocketchat_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/servicenow_test.py
+++ b/tests/alerters/servicenow_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/slack_test.py
+++ b/tests/alerters/slack_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/telegram_test.py
+++ b/tests/alerters/telegram_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 from requests.auth import HTTPProxyAuth

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/victorops_test.py
+++ b/tests/alerters/victorops_test.py
@@ -1,6 +1,6 @@
 import json
 
-import mock
+from unittest import mock
 import pytest
 from requests import RequestException
 

--- a/tests/alerters/zabbix_test.py
+++ b/tests/alerters/zabbix_test.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from elastalert.alerters.zabbix import ZabbixAlerter
 from elastalert.loaders import FileRulesLoader

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 
-import mock
+from unittest import mock
 
 from elastalert.alerts import Alerter
 from elastalert.alerts import BasicMatchString

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -5,7 +5,7 @@ import json
 import threading
 
 import elasticsearch
-import mock
+from unittest import mock
 import pytest
 from elasticsearch.exceptions import ConnectionError
 from elasticsearch.exceptions import ElasticsearchException

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-import mock
+from unittest import mock
 import datetime
 
 from elastalert.config import load_conf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import os
 
-import mock
+from unittest import mock
 import pytest
 
 import elastalert.elastalert

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -3,7 +3,7 @@ import copy
 import datetime
 import os
 
-import mock
+from unittest import mock
 import pytest
 
 import elastalert.alerts

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -2,7 +2,7 @@
 import copy
 import datetime
 
-import mock
+from unittest import mock
 import pytest
 
 from elastalert.ruletypes import AnyRule

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from datetime import timedelta
 
-import mock
+from unittest import mock
 import pytest
 from dateutil.parser import parse as dt
 


### PR DESCRIPTION
In Python (3.3 or later), unittest.mock is provided as a standard library for unit test mock, so replace the mock to be installed with the standard library.