### PR TITLE
Fix Github link in Helm chart documentation

### DIFF
--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -105,8 +105,8 @@ As a Kubernetes deployment
 The Docker container for ElastAlert 2 can be used directly as a Kubernetes
 deployment, but for convenience, a Helm chart is also available. See the
 instructions provided `on Github
-<https://hub.docker.com/r/jertel/elastalert2>`_ for more information on
-how to install, configure, and run the chart.
+<https://github.com/jertel/elastalert2/blob/master/chart/elastalert2/README.md>`_
+for more information on how to install, configure, and run the chart.
 
 .. _python-instructions:
 


### PR DESCRIPTION
Fixes documentation issue mentioned in #241 