### PR TITLE
fix: metrics_writeback takes three positional arguments

### DIFF
--- a/elastalert/prometheus_wrapper.py
+++ b/elastalert/prometheus_wrapper.py
@@ -33,7 +33,7 @@ class PrometheusWrapper:
         finally:
             return self.run_rule(rule, endtime, starttime)
 
-    def metrics_writeback(self, doc_type, body):
+    def metrics_writeback(self, doc_type, body, rule=None, match_body=None):
         """ Update various prometheus metrics accoording to the doc_type """
 
         res = self.writeback(doc_type, body)


### PR DESCRIPTION
Hey, running on 2.1.0 I'm hitting that when activating the prometheus metrics wrapper.

Cheers,

```
ERROR:elastalert:Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/elastalert/elastalert.py", line 1506, in alert
    return self.send_alert(matches, rule, alert_time=alert_time, retried=retried)
  File "/usr/local/lib/python3.9/site-packages/elastalert/elastalert.py", line 1615, in send_alert
    res = self.writeback('elastalert', alert_body, rule)
TypeError: metrics_writeback() takes 3 positional arguments but 4 were given
```