### PR TITLE
Tidy the documentation for ElastAlert invocation options

### DIFF
--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -27,19 +27,25 @@ verboseness, change all alerts to ``DebugAlerter``, which prints alerts and
 suppresses their normal action, and skips writing search and alert metadata back
 to Elasticsearch. Not compatible with `--verbose`.
 
-``--verbose`` will increase the logging verboseness, which allows you to see
-information about the state of queries. Not compatible with `--debug`.
+``--end <timestamp>`` will force ElastAlert to stop querying after the given
+time, instead of the default, querying to the present time. This really only
+makes sense when running standalone. The timestamp is formatted as
+``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00``
+(UTC-XX).
 
-``--start <timestamp>`` will force ElastAlert to begin querying from the given
-time, instead of the default, querying from the present. The timestamp should be
-ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
-``YYYY-MM-DDTHH:MM:SS-08:00`` (PST). Note that if querying over a large date
-range, no alerts will be sent until that rule has finished querying over the
-entire time period. To force querying from the current time, use "NOW".
+``--es_debug`` will enable logging for all queries made to Elasticsearch.
 
-``--end <timestamp>`` will cause ElastAlert to stop querying at the specified
-timestamp. By default, ElastAlert will periodically query until the present
-indefinitely.
+``--es_debug_trace <trace.log>`` will enable logging curl commands for all
+queries made to Elasticsearch to the specified log file. ``--es_debug_trace`` is
+passed through to `elasticsearch.py
+<http://elasticsearch-py.readthedocs.io/en/master/index.html#logging>`_ which
+logs `localhost:9200` instead of the actual ``es_host``:``es_port``.
+
+``--pin_rules`` will stop ElastAlert from loading, reloading or removing rules
+based on changes to their config files.
+
+``--prometheus_port`` exposes ElastAlert Prometheus metrics on the specified
+port. Prometheus metrics disabled by default.
 
 ``--rule <rule.yaml>`` will only run the given rule. The rule file may be a
 complete file path or a filename in ``rules_folder`` or its subdirectories.
@@ -50,22 +56,15 @@ days, weeks, hours, minutes or seconds. <number> is an integer. For example,
 ``--rule noisy_rule.yaml --silence hours=4`` will stop noisy_rule from
 generating any alerts for 4 hours.
 
-``--es_debug`` will enable logging for all queries made to Elasticsearch.
+``--start <timestamp>`` will force ElastAlert to begin querying from the given
+time, instead of the default, querying from the present. The timestamp should be
+ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
+``YYYY-MM-DDTHH:MM:SS-08:00`` (PST). Note that if querying over a large date
+range, no alerts will be sent until that rule has finished querying over the
+entire time period. To force querying from the current time, use "NOW".
 
-``--es_debug_trace <trace.log>`` will enable logging curl commands for all
-queries made to Elasticsearch to the specified log file. ``--es_debug_trace`` is
-passed through to `elasticsearch.py
-<http://elasticsearch-py.readthedocs.io/en/master/index.html#logging>`_ which
-logs `localhost:9200` instead of the actual ``es_host``:``es_port``.
-
-``--end <timestamp>`` will force ElastAlert to stop querying after the given
-time, instead of the default, querying to the present time. This really only
-makes sense when running standalone. The timestamp is formatted as
-``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00``
-(UTC-XX).
-
-``--pin_rules`` will stop ElastAlert from loading, reloading or removing rules
-based on changes to their config files.
+``--verbose`` will increase the logging verboseness, which allows you to see
+information about the state of queries. Not compatible with `--debug`.
 
 .. _docker-instructions:
 


### PR DESCRIPTION
- Add basic documentation of the Prometheus wrapper (from the old README, cc @greut)
- Remove duplicate documentation of the `--end` flag
- Alphabetise the option so it's easier to search through them (and find duplicates)