### PR TITLE
Added error handling for unsupported operand type

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -456,6 +456,11 @@ query_delay
 ``query_delay``: This option will cause ElastAlert to subtract a time delta from every query, causing the rule to run with a delay.
 This is useful if the data is Elasticsearch doesn't get indexed immediately. (Optional, time)
 
+For example::
+
+    query_delay:
+      hours: 2
+
 owner
 ^^^^^
 


### PR DESCRIPTION
- Added error handling because it fails with an error when the description of query_delay and aggregation is insufficient.

This is a problem with the following issue on yelp / elastalert.

https://github.com/Yelp/elastalert/issues/3103
https://github.com/Yelp/elastalert/issues/2613

- Added a description example to the query_delay documentation.