### PR TITLE
Fix Datadog Alerter

### DIFF
--- a/elastalert/alerters/datadog.py
+++ b/elastalert/alerters/datadog.py
@@ -32,7 +32,7 @@ class DatadogAlerter(Alerter):
             response.raise_for_status()
         except RequestException as e:
             raise EAException('Error posting event to Datadog: %s' % e)
-    elastalert_logger.info('Alert sent to Datadog')
+        elastalert_logger.info('Alert sent to Datadog')
 
     def get_info(self):
         return {'type': 'datadog'}


### PR DESCRIPTION
The info log was not output when the alert was notified normally, so this has been fixed. Added log test.