### PR TITLE
Bump pytest-xdist from 2.2.1 to 2.3.0 / Added info log output to command.py and thehive.py etc

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1896,7 +1896,7 @@ an email would be sent to ``qlo@example.com``
 
 ``smtp_host``: The SMTP host to use, defaults to localhost.
 
-``smtp_port``: The port to use. If smtp_port is not specified when smtp_ssl is False, 25 ports will be set internally. If smtp_port is not specified when smtp_ssl is True, 465 ports will be set internally.
+``smtp_port``: The port to use. Defaults to port 25 when SSL is not used, or 465 when SSL is used.
 
 ``smtp_ssl``: Connect the SMTP host using TLS, defaults to ``false``. If ``smtp_ssl`` is not used, ElastAlert will still attempt
 STARTTLS.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1848,7 +1848,7 @@ Optional:
 
 ``discord_emoji_title``: By default ElastAlert will use the ``:warning:`` emoji when posting to the channel. You can use a different emoji per ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If slack_icon_url_override parameter is provided, emoji is ignored.
 
-``discord_proxy``: By default ElastAlert will not use a network proxy to send notifications to Discord. Set this option using ``hostname:port`` if you need to use a proxy.
+``discord_proxy``: By default ElastAlert will not use a network proxy to send notifications to Discord. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``discord_proxy_login``: The Discord proxy auth username.
 
@@ -1896,7 +1896,7 @@ an email would be sent to ``qlo@example.com``
 
 ``smtp_host``: The SMTP host to use, defaults to localhost.
 
-``smtp_port``: The port to use. Default is 25.
+``smtp_port``: The port to use. If smtp_port is not specified when smtp_ssl is False, 25 ports will be set internally. If smtp_port is not specified when smtp_ssl is True, 465 ports will be set internally.
 
 ``smtp_ssl``: Connect the SMTP host using TLS, defaults to ``false``. If ``smtp_ssl`` is not used, ElastAlert will still attempt
 STARTTLS.
@@ -1978,7 +1978,7 @@ Optional:
 
 ``gitter_msg_level``: By default the alert will be posted with the 'error' level. You can use 'info' if you want the messages to be black instead of red.
 
-``gitter_proxy``: By default ElastAlert will not use a network proxy to send notifications to Gitter. Set this option using ``hostname:port`` if you need to use a proxy.
+``gitter_proxy``: By default ElastAlert will not use a network proxy to send notifications to Gitter. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 Example usage::
 
@@ -2024,7 +2024,7 @@ Optional:
 
 ``http_post_headers``: Key:value pairs of headers to be sent as part of the request.
 
-``http_post_proxy``: URL of proxy, if required.
+``http_post_proxy``: URL of proxy, if required. only supports https.
 
 ``http_post_all_values``: Boolean of whether or not to include every key value pair from the match in addition to those in http_post_payload and http_post_static_payload. Defaults to True if http_post_payload is not specified, otherwise False.
 
@@ -2183,7 +2183,7 @@ The alerter requires the following option:
 
 Optional:
 
-``mattermost_proxy``: By default ElastAlert will not use a network proxy to send notifications to Mattermost. Set this option using ``hostname:port`` if you need to use a proxy.
+``mattermost_proxy``: By default ElastAlert will not use a network proxy to send notifications to Mattermost. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``mattermost_ignore_ssl_errors``: By default ElastAlert will verify SSL certificate. Set this option to ``False`` if you want to ignore SSL errors.
 
@@ -2252,7 +2252,7 @@ Optional:
 
 ``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
 
-``ms_teams_proxy``: By default ElastAlert will not use a network proxy to send notifications to MS Teams. Set this option using ``hostname:port`` if you need to use a proxy.
+``ms_teams_proxy``: By default ElastAlert will not use a network proxy to send notifications to MS Teams. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``ms_teams_alert_fixed_width``: By default this is ``False`` and the notification will be sent to MS Teams as-is. Teams supports a partial Markdown implementation, which means asterisk, underscore and other characters may be interpreted as Markdown. Currenlty, Teams does not fully implement code blocks. Setting this attribute to ``True`` will enable line by line code blocks. It is recommended to enable this to get clearer notifications in Teams.
 
@@ -2309,7 +2309,7 @@ Optional:
 
 ``opsgenie_details``: Map of custom key/value pairs to include in the alert's details. The value can sourced from either fields in the first match, environment variables, or a constant value.
 
-``opsgenie_proxy``: By default ElastAlert will not use a network proxy to send notifications to OpsGenie. Set this option using ``hostname:port`` if you need to use a proxy.
+``opsgenie_proxy``: By default ElastAlert will not use a network proxy to send notifications to OpsGenie. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 Example usage::
 
@@ -2342,7 +2342,7 @@ If there's no open (i.e. unresolved) incident with this key, a new one will be c
 
 ``pagerduty_incident_key_args``: If set, and ``pagerduty_incident_key`` is a formattable string, ElastAlert 2 will format the incident key based on the provided array of fields from the rule or match.
 
-``pagerduty_proxy``: By default ElastAlert will not use a network proxy to send notifications to PagerDuty. Set this option using ``hostname:port`` if you need to use a proxy.
+``pagerduty_proxy``: By default ElastAlert will not use a network proxy to send notifications to PagerDuty. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 V2 API Options (Optional):
 
@@ -2383,7 +2383,7 @@ The alerter requires the following options:
 
 ``pagertree_integration_url``: URL generated by PagerTree for the integration.
 
-``pagertree_proxy``: By default ElastAlert will not use a network proxy to send notifications to PagerTree. Set this option using ``hostname:port`` if you need to use a proxy.
+``pagertree_proxy``: By default ElastAlert will not use a network proxy to send notifications to PagerTree. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 Example usage::
 
@@ -2414,7 +2414,7 @@ ElastAlert rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ .
 
 ``rocket_chat_text_string``: Notification message you want to add.
 
-``rocket_chat_proxy``: By default ElastAlert will not use a network proxy to send notifications to Rocket.Chat. Set this option using ``hostname:port`` if you need to use a proxy.
+``rocket_chat_proxy``: By default ElastAlert will not use a network proxy to send notifications to Rocket.Chat. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``rocket_chat_attach_kibana_discover_url``: Enables the attachment of the ``kibana_discover_url`` to the Rocket.Chat notification. The config ``generate_kibana_discover_url`` must also be ``True`` in order to generate the url. Defaults to ``False``.
 
@@ -2482,7 +2482,7 @@ The alerter requires the following options:
 
 Optional:
 
-``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy.
+``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 Example usage::
 
@@ -2528,7 +2528,7 @@ Provide absolute address of the pciture.
 
 ``slack_text_string``: Notification message you want to add.
 
-``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy.
+``slack_proxy``: By default ElastAlert will not use a network proxy to send notifications to Slack. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``slack_alert_fields``: You can add additional fields to your slack alerts using this field. Specify the title using `title` and a value for the field using `value`. Additionally you can specify whether or not this field should be a `short` field using `short: true`.
 
@@ -2596,7 +2596,7 @@ Optional:
 
 ``victorops_entity_display_name``: Human-readable name of alerting entity to summarize incidents without affecting the life-cycle workflow.
 
-``victorops_proxy``: By default ElastAlert will not use a network proxy to send notifications to Splunk On-Call (Formerly VictorOps). Set this option using ``hostname:port`` if you need to use a proxy.
+``victorops_proxy``: By default ElastAlert will not use a network proxy to send notifications to Splunk On-Call (Formerly VictorOps). Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 Example usage::
 
@@ -2654,7 +2654,7 @@ Optional:
 
 ``telegram_api_url``: Custom domain to call Telegram Bot API. Default to api.telegram.org
 
-``telegram_proxy``: By default ElastAlert will not use a network proxy to send notifications to Telegram. Set this option using ``hostname:port`` if you need to use a proxy.
+``telegram_proxy``: By default ElastAlert will not use a network proxy to send notifications to Telegram. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
 ``telegram_proxy_login``: The Telegram proxy auth username.
 

--- a/elastalert/alerters/command.py
+++ b/elastalert/alerters/command.py
@@ -43,6 +43,7 @@ class CommandAlerter(Alerter):
                 raise EAException("Non-zero exit code while running command %s" % (' '.join(command)))
         except OSError as e:
             raise EAException("Error while running command %s: %s" % (' '.join(command), e))
+        elastalert_logger.info("Alert sent to Command")
 
     def get_info(self):
         return {'type': 'command',

--- a/elastalert/alerters/email.py
+++ b/elastalert/alerters/email.py
@@ -25,7 +25,7 @@ class EmailAlerter(Alerter):
         self.smtp_host = self.rule.get('smtp_host', 'localhost')
         self.smtp_ssl = self.rule.get('smtp_ssl', False)
         self.from_addr = self.rule.get('from_addr', 'ElastAlert')
-        self.smtp_port = self.rule.get('smtp_port', 25)
+        self.smtp_port = self.rule.get('smtp_port')
         if self.rule.get('smtp_auth_file'):
             self.get_account(self.rule['smtp_auth_file'])
         self.smtp_key_file = self.rule.get('smtp_key_file')
@@ -95,11 +95,13 @@ class EmailAlerter(Alerter):
                 if self.smtp_port:
                     self.smtp = SMTP_SSL(self.smtp_host, self.smtp_port, keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
                 else:
+                    # default port : 465
                     self.smtp = SMTP_SSL(self.smtp_host, keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
             else:
                 if self.smtp_port:
                     self.smtp = SMTP(self.smtp_host, self.smtp_port)
                 else:
+                    # default port : 25
                     self.smtp = SMTP(self.smtp_host)
                 self.smtp.ehlo()
                 if self.smtp.has_extn('STARTTLS'):

--- a/elastalert/alerters/thehive.py
+++ b/elastalert/alerters/thehive.py
@@ -6,7 +6,7 @@ import requests
 from requests import RequestException
 
 from elastalert.alerts import Alerter
-from elastalert.util import lookup_es_key, EAException
+from elastalert.util import lookup_es_key, EAException, elastalert_logger
 
 
 class HiveAlerter(Alerter):
@@ -123,6 +123,7 @@ class HiveAlerter(Alerter):
             response.raise_for_status()
         except RequestException as e:
             raise EAException(f"Error posting to TheHive: {e}")
+        elastalert_logger.info("Alert sent to TheHive")
 
     def get_info(self):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pluggy>=0.12.0
 pre-commit
 pylint<2.9
 pytest==6.2.4
-pytest-xdist==2.2.1
+pytest-xdist==2.3.0
 setuptools
 sphinx_rtd_theme
 tox==3.23.1

--- a/tests/alerters/command_test.py
+++ b/tests/alerters/command_test.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import logging
 
 import pytest
 from unittest import mock
@@ -28,7 +29,8 @@ def test_command_getinfo():
     assert expected_data == actual_data
 
 
-def test_command_old_style_string_format1():
+def test_command_old_style_string_format1(caplog):
+    caplog.set_level(logging.INFO)
     # Test command as string with formatted arg (old-style string format)
     rule = {'command': '/bin/test/ --arg %(somefield)s'}
     match = {'@timestamp': '2014-01-01T00:00:00',
@@ -38,6 +40,8 @@ def test_command_old_style_string_format1():
     with mock.patch("elastalert.alerters.command.subprocess.Popen") as mock_popen:
         alert.alert([match])
     assert mock_popen.called_with('/bin/test --arg foobarbaz', stdin=subprocess.PIPE, shell=False)
+    assert ('elastalert', logging.WARNING, 'Warning! You could be vulnerable to shell injection!') == caplog.record_tuples[0]
+    assert ('elastalert', logging.INFO, 'Alert sent to Command') == caplog.record_tuples[1]
 
 
 def test_command_old_style_string_format2():


### PR DESCRIPTION
**pytest-xdist**

Updated from 2.2.1 to 2.3.0

**Deleted the default value setting of smtp_port**

When I checked the [source code of smtplib](https://github.com/python/cpython/blob/3.9/Lib/smtplib.py), I found that it was 25 or 465 when I did not specify the port, so I deleted the default value specification. Added the default value to the smtp_port documentation.
https://github.com/jertel/elastalert2/pull/143

**Added info log output to command.py and thehive.py**

Only the hive and command were added because the info log was not output when the alert was notified normally.

**Addition of explanation of proxy setting**

Added that only https is available for alerts with proxy settings.
