### PR TITLE
Fix timezone conversion check

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -628,7 +628,7 @@ class ElastAlerter(object):
         if end is None:
             end = ts_now()
 
-        if rule.get('query_timezone') is not None:
+        if rule.get('query_timezone'):
             elastalert_logger.info("Query start and end time converting UTC to query_timezone : {}".format(rule.get('query_timezone')))
             start = ts_utc_to_tz(start, rule.get('query_timezone'))
             end = ts_utc_to_tz(end, rule.get('query_timezone'))

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -628,7 +628,7 @@ class ElastAlerter(object):
         if end is None:
             end = ts_now()
 
-        if rule.get('query_timezone') != "":
+        if rule.get('query_timezone') is not None:
             elastalert_logger.info("Query start and end time converting UTC to query_timezone : {}".format(rule.get('query_timezone')))
             start = ts_utc_to_tz(start, rule.get('query_timezone'))
             end = ts_utc_to_tz(end, rule.get('query_timezone'))


### PR DESCRIPTION
I noticed today that `make test` had started failing on my machine
when run outside of the Docker container.

This was due to the fact that a timezone wasn't being set correctly
when run on my machine, which is on BST. The test worked fine with
the container because it was on UTC.

I traced the error down to https://github.com/jertel/elastalert2/pull/51,
in particular, a check which would return True in some cases where
it wasn't intended, because get() returns a None value by default
instead of the expected empty string.