### PR TITLE
Implements ms_teams params as configurable env variables

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2252,8 +2252,10 @@ Optional:
 
 Example usage::
 
-  // Environment variables set in the system
+  // Environment variables set in the system - it is possible to use a list of urls here
   MY_PREFIX_MS_TEAMS_WEBHOOK_URL="https://mysite.webhook.office.com/webhookb2/SOME_UUID@SOME_UUID/IncomingWebhook/SOME_ID/SOME_UUID"
+  // or like this using a list separated by comma
+  MY_PREFIX_MS_TEAMS_WEBHOOK_URL="https://mysite.webhook.office.com/webhookb2/SOME_UUID@SOME_UUID/IncomingWebhook/SOME_ID/SOME_UUID, https://mysite.webhook.office.com/webhookb2/SOME_UUID@SOME_UUID/IncomingWebhook/SOME_ID/SOME_UUID"
   MY_PREFIX_ms_teams_proxy="127.0.0.1"
 
   alert:

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2244,15 +2244,27 @@ Microsoft Teams alerter will send a notification to a predefined Microsoft Teams
 The alerter requires the following options:
 
 ``ms_teams_webhook_url``: The webhook URL that includes your auth data and the ID of the channel you want to post to. Go to the Connectors
-menu in your channel and configure an Incoming Webhook, then copy the resulting URL. You can use a list of URLs to send to multiple channels.
+menu in your channel and configure an Incoming Webhook, then copy the resulting URL. You can use a list of URLs to send to multiple channels. This can be overwritten by an environment variable. See the optional section for how this works.
 
 Optional:
+
+``ms_teams_env_prefix``: This variable can be set to load the `ms_teams_webhook_url` and the `ms_teams_proxy` from an environment variable instead of the rule, which enables the use of Kubernetes secrets and alike for storing these sensible information. Assign a value and concat the prefix with the `ms_teams_webhook_url`, `ms_teams_proxy` environment variables if desired. Take a look at the example below.
+
+Example usage::
+
+  // Environment variables set in the system
+  MY_PREFIX_MS_TEAMS_WEBHOOK_URL="https://mysite.webhook.office.com/webhookb2/SOME_UUID@SOME_UUID/IncomingWebhook/SOME_ID/SOME_UUID"
+  MY_PREFIX_ms_teams_proxy="127.0.0.1"
+
+  alert:
+    - "ms_teams"
+  ms_teams_env_prefix: "MY_PREFIX"
 
 ``ms_teams_alert_summary``: Summary should be configured according to `MS documentation <https://docs.microsoft.com/en-us/outlook/actionable-messages/card-reference>`_, although it seems not displayed by Teams currently, defaults to ``ElastAlert Message``.
 
 ``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
 
-``ms_teams_proxy``: By default ElastAlert will not use a network proxy to send notifications to MS Teams. Set this option using ``hostname:port`` if you need to use a proxy.
+``ms_teams_proxy``: By default ElastAlert will not use a network proxy to send notifications to MS Teams. Set this option using ``hostname:port`` if you need to use a proxy. This field can be overwritten using an environment variable. To overwrite it, create an environment variable using the form YOUR_PREFIX_MS_TEAMS_WEBHOOK_URL with the desired value and set the `ms_teams_env_prefix` alert configuration variable to your desired prefix.
 
 ``ms_teams_alert_fixed_width``: By default this is ``False`` and the notification will be sent to MS Teams as-is. Teams supports a partial Markdown implementation, which means asterisk, underscore and other characters may be interpreted as Markdown. Currenlty, Teams does not fully implement code blocks. Setting this attribute to ``True`` will enable line by line code blocks. It is recommended to enable this to get clearer notifications in Teams.
 

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -17,21 +17,24 @@ class MsTeamsAlerter(Alerter):
         teams_settings = {'ms_teams_webhook_url': None,
                           'ms_teams_proxy': None}
 
+        self.ms_teams_webhook_url = None
         teams_settings['ms_teams_webhook_url'] = self.rule.get('ms_teams_webhook_url', None)
         teams_settings['ms_teams_proxy'] = self.rule.get('ms_teams_proxy', None)
 
-        # Optional overwrite the settings using environment variable values
+        # Optional: overwrite the settings using environment variable values
         self.ms_teams_env_prefix = self.rule.get('ms_teams_env_prefix', None)
         if self.ms_teams_env_prefix is not None:
             webhookUrl = os.environ.get(self.ms_teams_env_prefix + '_MS_TEAMS_WEBHOOK_URL')
             if webhookUrl is not None:
-                teams_settings['ms_teams_webhook_url'] = webhookUrl
+                print(webhookUrl)
+                teams_settings['ms_teams_webhook_url'] = webhookUrl.replace(' ', '').split(',')
+                self.ms_teams_webhook_url = teams_settings['ms_teams_webhook_url']
+                print(self.ms_teams_webhook_url)
 
             webhookProxy = os.environ.get(self.ms_teams_env_prefix + '_MS_TEAMS_PROXY')
             if webhookProxy is not None:
                 teams_settings['ms_teams_proxy'] = webhookProxy
 
-        self.ms_teams_webhook_url = None
         if isinstance(teams_settings['ms_teams_webhook_url'], str):
             self.ms_teams_webhook_url = [teams_settings['ms_teams_webhook_url']]
 

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -9,13 +9,12 @@ from requests.exceptions import RequestException
 
 class MsTeamsAlerter(Alerter):
     """ Creates a Microsoft Teams Conversation Message for each alert """
-    required_options = frozenset(['ms_teams_webhook_url'])
+    required_options = frozenset([])
 
     def __init__(self, rule):
         super(MsTeamsAlerter, self).__init__(rule)
 
-        teams_settings = {'ms_teams_webhook_url': None,
-                          'ms_teams_proxy': None}
+        teams_settings = {}
 
         self.ms_teams_webhook_url = None
         teams_settings['ms_teams_webhook_url'] = self.rule.get('ms_teams_webhook_url', None)

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -84,7 +84,9 @@ def test_env_ms_teams_webhook_url():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@mock.patch.dict(os.environ, {"TEST_RULE_1_MS_TEAMS_WEBHOOK_URL": "http://test.webhook.url, http://test1.webhook.url, http://test2.webhook.url"})
+@mock.patch.dict(os.environ, {
+    "TEST_RULE_1_MS_TEAMS_WEBHOOK_URL": "http://test.webhook.url, http://test1.webhook.url, http://test2.webhook.url"
+})
 def test_env_multiple_ms_teams_webhook_url():
     rule = {
         'ms_teams_env_prefix': 'TEST_RULE_1',


### PR DESCRIPTION
Hello jertel and community,

first i want to thank you for the great work with elastalert2. We are using it at work and are so happy to have it. I wanted to give something back.

We had the requirement not to add credentials (like usernames, password, but also webhook urls) into the repository of the rules. We are handling credentials in kubernetes secrets all the way. So i created this pull request. And this is what it does.

- Remove the requirement for the ms_teams_webhook_url setting in the Microsoft Teams alert - basically transforming this to an optional setting. Still works if set though.
- Instead enables the user to define an environment variable that contains the value for the setting

The process works like this
1. The user can define a new prefix variable in the alerter settings like this: ms_teams_env_prefix: "MY_PREFIX"
2. Then the user will create an environment var using the prefix and the fixed identifier for the settings like this: MY_PREFIX_MS_TEAMS_WEBHOOK_URL="https://webhookurlhere"
3. This will enable the user to create various env variables for various teams alerters by just changing the prefix or even using the same prefix if the webhook url is used more than once
3. Then just use the alerter as normal

1. This also works for the proxy setting, too. You can set it via env variable but this is optional, too. It also uses the prefix.

- Documentation is updated and included
- Tests are updated and included for the new additions

Please let me know if i could do something better or something is not correctly done. I am not that fluent in python :)

Best regards, keep up the good work