### PR TITLE
Reducing the unused calls to elasticsearch_client

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -859,6 +859,14 @@ class ElastAlerter(object):
             filters.append({'query': query_str_filter})
         elastalert_logger.debug("Enhanced filter with {} terms: {}".format(listname, str(query_str_filter)))
 
+    def get_elasticsearch_client(self, rule):
+        key = rule['name']
+        es_client = self.es_clients.get(key)
+        if es_client is None:
+            es_client = elasticsearch_client(rule)
+            self.es_clients[key] = es_client
+        return es_client
+
     def run_rule(self, rule, endtime, starttime=None):
         """ Run a rule for a given time period, including querying and alerting on results.
 
@@ -868,7 +876,7 @@ class ElastAlerter(object):
         :return: The number of matches that the rule produced.
         """
         run_start = time.time()
-        self.thread_data.current_es = self.es_clients.setdefault(rule['name'], elasticsearch_client(rule))
+        self.thread_data.current_es = self.get_elasticsearch_client(rule)
 
         # If there are pending aggregate matches, try processing them
         for x in range(len(rule['agg_matches'])):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1426,3 +1426,20 @@ def test_add_aggregated_alert_error(ea, caplog):
         exceptd = "[add_aggregated_alert]"
         exceptd += "Error parsing aggregate send time format unsupported operand type(s) for +: 'datetime.datetime' and 'dict'"
         assert exceptd in message
+
+
+def test_get_elasticsearch_client_same_rule(ea):
+    x = ea.get_elasticsearch_client(ea.rules[0])
+    y = ea.get_elasticsearch_client(ea.rules[0])
+    assert x is y, "Should return same client for the same rule"
+
+
+def test_get_elasticsearch_client_different_rule(ea):
+    x_rule = ea.rules[0]
+    x = ea.get_elasticsearch_client(x_rule)
+
+    y_rule = copy.copy(x_rule)
+    y_rule['name'] = 'different_rule'
+    y = ea.get_elasticsearch_client(y_rule)
+
+    assert x is not y, 'Should return unique client for each rule'


### PR DESCRIPTION
Adding helper method to reduce the number of unnecessary calls to `elasticsearch_client` helper method.