### PR TITLE
Fixing zabbix timezone code

### DIFF
--- a/elastalert/alerters/zabbix.py
+++ b/elastalert/alerters/zabbix.py
@@ -57,7 +57,7 @@ class ZabbixAlerter(Alerter):
         self.zbx_key = self.rule.get('zbx_key', None)
         self.timestamp_field = self.rule.get('timestamp_field', '@timestamp')
         self.timestamp_type = self.rule.get('timestamp_type', 'iso')
-        self.timestamp_strptime = self.rule.get('timestamp_strptime', '%Y-%m-%dT%H:%M:%S.%fZ')
+        self.timestamp_strptime = self.rule.get('timestamp_strptime', '%Y-%m-%dT%H:%M:%S.%f%z')
 
     # Alert is called
     def alert(self, matches):
@@ -72,10 +72,10 @@ class ZabbixAlerter(Alerter):
             else:
                 try:
                     ts_epoch = int(datetime.strptime(match[self.timestamp_field], self.timestamp_strptime)
-                                   .strftime('%s'))
+                                   .timestamp())
                 except ValueError:
-                    ts_epoch = int(datetime.strptime(match[self.timestamp_field], '%Y-%m-%dT%H:%M:%SZ')
-                                   .strftime('%s'))
+                    ts_epoch = int(datetime.strptime(match[self.timestamp_field], '%Y-%m-%dT%H:%M:%S%z')
+                                   .timestamp())
             zm.append(ZabbixMetric(host=self.zbx_host, key=self.zbx_key, value='1', clock=ts_epoch))
 
         try:


### PR DESCRIPTION
@nsano-rururu, the test case `test_zabbix_basic` fails if the current timezone is not UTC.

```
=================================== FAILURES ===================================
______________________________ test_zabbix_basic _______________________________

caplog = <_pytest.logging.LogCaptureFixture object at 0x7fabd89de190>

    def test_zabbix_basic(caplog):
        caplog.set_level(logging.WARNING)
        rule = {
            'name': 'Basic Zabbix test',
            'type': 'any',
            'alert_text_type': 'alert_text_only',
            'alert': [],
            'alert_subject': 'Test Zabbix',
            'zbx_host': 'example.com',
            'zbx_key': 'example-key'
        }
        rules_loader = FileRulesLoader({})
        rules_loader.load_modules(rule)
        alert = ZabbixAlerter(rule)
        match = {
            '@timestamp': '2021-01-01T00:00:00Z',
            'somefield': 'foobarbaz'
        }
        with mock.patch('pyzabbix.ZabbixSender.send') as mock_zbx_send:
            alert.alert([match])
    
            zabbix_metrics = {
                "host": "example.com",
                "key": "example-key",
                "value": "1",
                "clock": 1609459200
            }
            alerter_args = mock_zbx_send.call_args.args
>           assert vars(alerter_args[0][0]) == zabbix_metrics
E           AssertionError: assert {'clock': 160... 'value': '1'} == {'clock': 160... 'value': '1'}
E             Omitting 3 identical items, use -vv to show
E             Differing items:
E             {'clock': 1609477200} != {'clock': 1609459200}
E             Use -v to get the full diff

tests/alerters/zabbix_test.py:39: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  elastalert:zabbix.py:84 Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded
------------- generated xml file: /tmp/tmp-135248PYktsmhWQN7b.xml --------------
=========================== short test summary info ============================
FAILED tests/alerters/zabbix_test.py::test_zabbix_basic - AssertionError: ass...
========================= 1 failed, 6 passed in 0.57s ==========================
```