### PR TITLE
[Opsgenie] Added possibility to specify `source` and `entity` attrs

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2340,11 +2340,15 @@ Optional:
 
 ``opsgenie_subject_args``: A list of fields to use to format ``opsgenie_subject`` if it contains formaters.
 
-``opsgenie_priority``: Set the OpsGenie priority level. Possible values are P1, P2, P3, P4, P5.
+``opsgenie_priority``: Set the OpsGenie priority level. Possible values are P1, P2, P3, P4, P5. Can be formatted with fields from the first match e.g "P{level}"
 
 ``opsgenie_details``: Map of custom key/value pairs to include in the alert's details. The value can sourced from either fields in the first match, environment variables, or a constant value.
 
 ``opsgenie_proxy``: By default ElastAlert will not use a network proxy to send notifications to OpsGenie. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
+
+``opsgenie_source``: Set the OpsGenie source, default is `ElastAlert`. Can be formatted with fields from the first match e.g "{source} {region}"
+
+``opsgenie_entity``: Set the OpsGenie entity. Can be formatted with fields from the first match e.g "{host_name}"
 
 Example usage::
 

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -4,7 +4,7 @@ import os.path
 import requests
 
 from elastalert.alerts import Alerter, BasicMatchString
-from elastalert.util import EAException, elastalert_logger, lookup_es_key, resolve_string
+from elastalert.util import EAException, elastalert_logger, lookup_es_key
 
 
 class OpsGenieAlerter(Alerter):

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -89,7 +89,7 @@ class OpsGenieAlerter(Alerter):
 
         priority = self.priority
         if priority:
-            priority = self.priority.format(**matches[0])
+            priority = priority.format(**matches[0])
         if priority and priority not in ('P1', 'P2', 'P3', 'P4', 'P5'):
             elastalert_logger.warning("Priority level does not appear to be specified correctly. \
                         Please make sure to set it to a value between P1 and P5")

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -443,6 +443,8 @@ properties:
   opsgenie_subject: {type: string}
   opsgenie_priority: {type: string}
   opsgenie_proxy: {type: string}
+  opsgenie_source: {type: string}
+  opsgenie_entity: {type: string}
   opsgenie_details:
     type: object
     minProperties: 1

--- a/examples/rules/example_opsgenie_frequency.yaml
+++ b/examples/rules/example_opsgenie_frequency.yaml
@@ -24,7 +24,7 @@ opsgenie_key: ogkey
 # (Optional)
 # OpsGenie recipients with args
 # opsgenie_recipients:
-#   - {recipient} 
+#   - {recipient}
 # opsgenie_recipients_args:
 #     team_prefix:'user.email'
 
@@ -36,7 +36,7 @@ opsgenie_key: ogkey
 # (Optional)
 # OpsGenie teams with args
 # opsgenie_teams:
-#   - {team_prefix}-Team 
+#   - {team_prefix}-Team
 # opsgenie_teams_args:
 #     team_prefix:'team'
 
@@ -44,6 +44,12 @@ opsgenie_key: ogkey
 # OpsGenie alert tags
 opsgenie_tags:
   - "Production"
+
+# (Optional) OpsGenie source
+# opsgenie_source: ElastAlert_EMEA
+
+# (Optional) OpsGenie entity
+# opsgenie_entity: '{hostname}'
 
 # (OptionaL) Connect with SSL to Elasticsearch
 #use_ssl: True


### PR DESCRIPTION
- Opsgenie alert's `source` attribute now can be specified in rule. 
  Previously it was hardcoded to `ElastAlert`, now it just the default. So this PR will not break previous behavior.
- Opsgenie alert's `entity` attribute now can be specified in rule.
- `priority` attribute can now be templated from the first match.