### PR TITLE
Add impact and urgency as optional params for the servicenow alerter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Improve structure and placement of test-related files in project tree - [#287](https://github.com/jertel/elastalert2/pull/287) - @ferozsalam
 - Only attempt to adjust timezone if timezone is set to a non-empty string - [#288](https://github.com/jertel/elastalert2/pull/288) - @ferozsalam
 - Deprecated `podSecurityPolicy` feature in Helm Chart as [it's deprecated in Kubernetes 1.21](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) - [#289](https://github.com/jertel/elastalert2/pull/289) - @lepouletsuisse
+- Add support for `impact` and `urgency` parameters for Servicenow alerter
 
 # 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Improve structure and placement of test-related files in project tree - [#287](https://github.com/jertel/elastalert2/pull/287) - @ferozsalam
 - Only attempt to adjust timezone if timezone is set to a non-empty string - [#288](https://github.com/jertel/elastalert2/pull/288) - @ferozsalam
 - Deprecated `podSecurityPolicy` feature in Helm Chart as [it's deprecated in Kubernetes 1.21](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) - [#289](https://github.com/jertel/elastalert2/pull/289) - @lepouletsuisse
-- Add support for `impact` and `urgency` parameters for Servicenow alerter
+- Add support for `servicenow_impact` and `servicenow_urgency` parameters for Servicenow alerter
 
 # 2.1.1
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2566,9 +2566,9 @@ Optional:
 
 ``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
-``impact``: An integer 1, 2, or 3 representing high, medium, and low respectively. This measures the effect of an incident on business processes.
+``servicenow_impact``: An integer 1, 2, or 3 representing high, medium, and low respectively. This measures the effect of an incident on business processes.
 
-``urgency``: An integer 1, 2, or 3 representing high, medium, and low respecitvely. This measures how long this incident can be delayed until there is a significant business impact.
+``servicenow_urgency``: An integer 1, 2, or 3 representing high, medium, and low respecitvely. This measures how long this incident can be delayed until there is a significant business impact.
 
 Example usage::
 
@@ -2584,6 +2584,8 @@ Example usage::
     subcategory: "xxxxxx"
     cmdb_ci: "xxxxxx"
     caller_id: "xxxxxx"
+    servicenow_impact: 1
+    servicenow_urgenc: 3
 
 Slack
 ~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2566,6 +2566,10 @@ Optional:
 
 ``servicenow_proxy``: By default ElastAlert will not use a network proxy to send notifications to ServiceNow. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
+``impact``: An integer 1, 2, or 3 representing high, medium, and low respectively. This measures the effect of an incident on business processes.
+
+``urgency``: An integer 1, 2, or 3 representing high, medium, and low respecitvely. This measures how long this incident can be delayed until there is a significant business impact.
+
 Example usage::
 
     alert:

--- a/elastalert/alerters/servicenow.py
+++ b/elastalert/alerters/servicenow.py
@@ -26,8 +26,8 @@ class ServiceNowAlerter(Alerter):
         super(ServiceNowAlerter, self).__init__(rule)
         self.servicenow_rest_url = self.rule.get('servicenow_rest_url', None)
         self.servicenow_proxy = self.rule.get('servicenow_proxy', None)
-        self.impact = self.rule.get('impact', None)
-        self.urgency = self.rule.get('urgency', None)
+        self.impact = self.rule.get('servicenow_impact', None)
+        self.urgency = self.rule.get('servicenow_urgency', None)
 
     def alert(self, matches):
         for match in matches:

--- a/elastalert/alerters/servicenow.py
+++ b/elastalert/alerters/servicenow.py
@@ -26,6 +26,8 @@ class ServiceNowAlerter(Alerter):
         super(ServiceNowAlerter, self).__init__(rule)
         self.servicenow_rest_url = self.rule.get('servicenow_rest_url', None)
         self.servicenow_proxy = self.rule.get('servicenow_proxy', None)
+        self.impact = self.rule.get('impact', None)
+        self.urgency = self.rule.get('urgency', None)
 
     def alert(self, matches):
         for match in matches:
@@ -48,6 +50,10 @@ class ServiceNowAlerter(Alerter):
             "cmdb_ci": self.rule['cmdb_ci'],
             "caller_id": self.rule["caller_id"]
         }
+        if self.impact != None:
+            payload["impact"] = self.impact
+        if self.urgency != None:
+            payload["urgency"] = self.urgency
         try:
             response = requests.post(
                 self.servicenow_rest_url,

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -506,6 +506,8 @@ properties:
   cmdb_ci: {type: string}
   caller_id: {type: string}
   servicenow_proxy: {type: string}
+  impact: {type: integer}
+  urgency: {type: integer}
 
   ### Slack
   slack_webhook_url: *arrayOfString

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -506,8 +506,8 @@ properties:
   cmdb_ci: {type: string}
   caller_id: {type: string}
   servicenow_proxy: {type: string}
-  impact: {type: integer}
-  urgency: {type: integer}
+  servicenow_impact: {type: integer}
+  servicenow_urgency: {type: integer}
 
   ### Slack
   slack_webhook_url: *arrayOfString

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -506,8 +506,8 @@ properties:
   cmdb_ci: {type: string}
   caller_id: {type: string}
   servicenow_proxy: {type: string}
-  servicenow_impact: {type: integer}
-  servicenow_urgency: {type: integer}
+  servicenow_impact: {type: integer, minimum: 1, maximum: 3}
+  servicenow_urgency: {type: integer, minimum: 1, maximum: 3}
 
   ### Slack
   slack_webhook_url: *arrayOfString

--- a/tests/alerters/servicenow_test.py
+++ b/tests/alerters/servicenow_test.py
@@ -131,8 +131,8 @@ def test_service_now_impact_and_urgency():
         'subcategory': 'ServiceNow subcategory',
         'cmdb_ci': 'ServiceNow cmdb_ci',
         'caller_id': 'ServiceNow caller_id',
-        'impact': '3',
-        'urgency': '1',
+        'servicenow_impact': 3,
+        'servicenow_urgency': 1,
         'alert': []
     }
     rules_loader = FileRulesLoader({})
@@ -146,8 +146,8 @@ def test_service_now_impact_and_urgency():
         alert.alert([match])
 
     data = json.loads(mock_post_request.call_args_list[0][1]['data'])
-    assert data['impact'] == rule['impact']
-    assert data['urgency'] == rule['urgency']
+    assert data['impact'] == rule['servicenow_impact']
+    assert data['urgency'] == rule['servicenow_urgency']
 
 
 def test_service_now_ea_exception():

--- a/tests/alerters/servicenow_test.py
+++ b/tests/alerters/servicenow_test.py
@@ -117,6 +117,39 @@ def test_service_now_proxy():
     assert expected_data == actual_data
 
 
+def test_service_now_impact_and_urgency():
+    rule = {
+        'name': 'Test ServiceNow Rule',
+        'type': 'any',
+        'username': 'ServiceNow username',
+        'password': 'ServiceNow password',
+        'servicenow_rest_url': 'https://xxxxxxxxxx',
+        'short_description': 'ServiceNow short_description',
+        'comments': 'ServiceNow comments',
+        'assignment_group': 'ServiceNow assignment_group',
+        'category': 'ServiceNow category',
+        'subcategory': 'ServiceNow subcategory',
+        'cmdb_ci': 'ServiceNow cmdb_ci',
+        'caller_id': 'ServiceNow caller_id',
+        'impact': '3',
+        'urgency': '1',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = ServiceNowAlerter(rule)
+    match = {
+        '@timestamp': '2021-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert data['impact'] == rule['impact']
+    assert data['urgency'] == rule['urgency']
+
+
 def test_service_now_ea_exception():
     with pytest.raises(EAException) as ea:
         rule = {


### PR DESCRIPTION
Extend the Servicenow alerter to support two new parameters: impact and urgency. 

More info on these parameters can be found on the [Servicenow doc page on defining priority lookup rules](https://docs.servicenow.com/bundle/quebec-it-service-management/page/product/incident-management/task/def-prio-lookup-rules.html).

These are added as optional parameters to ensure backwards compatibility.