### PR TITLE
Fix #317 - Add support jinja2 support to alert_subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## New features
 - Add support for generating Kibana Discover URLs to Rocket.Chat alerter - [#260](https://github.com/jertel/elastalert2/pull/260) - @nsanorururu
 - Provide rule key/values as possible Jinja data inputs - [#281](https://github.com/jertel/elastalert2/pull/281) - @mrfroggg
+- Add Jinja support to alert_subject - [#318](https://github.com/jertel/elastalert2/pull/318) - @mrfroggg
 - Add securityContext and podSecurityContext to Helm chart - [#289](https://github.com/jertel/elastalert2/pull/289) - @lepouletsuisse
 
 ## Other changes

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1435,7 +1435,7 @@ Similarly to ``alert_subject``, ``alert_text`` can be further formatted using Ji
 
 1. Jinja Template
 
-By setting ``alert_text_type: alert_text_jinja`` you can use jinja2 templates in ``alert_text``. ::
+By setting ``alert_text_type: alert_text_jinja`` you can use jinja2 templates in ``alert_text`` and ``alert_subject``. ::
 
     alert_text_type: alert_text_jinja
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -3,6 +3,7 @@ import copy
 import json
 import os
 
+from jinja2 import Template
 from texttable import Texttable
 
 from elastalert.util import EAException, lookup_es_key
@@ -210,7 +211,10 @@ class Alerter(object):
             missing = self.rule.get('alert_missing_value', '<MISSING VALUE>')
             alert_subject_values = [missing if val is None else val for val in alert_subject_values]
             alert_subject = alert_subject.format(*alert_subject_values)
-
+        elif self.rule.get('alert_text_type') == "alert_text_jinja":
+            title_template = Template(str(self.rule.get('alert_subject', '')))
+            template_values = self.rule | matches[0]
+            alert_subject = title_template.render(template_values | {self.rule['jinja_root_name']: template_values})
         if len(alert_subject) > alert_subject_max_len:
             alert_subject = alert_subject[:alert_subject_max_len]
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -274,3 +274,25 @@ def test_alert_subject_size_limit_with_args(ea):
     alert = Alerter(rule)
     alertSubject = alert.create_custom_title([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
     assert 6 == len(alertSubject)
+
+
+def test_alert_subject_with_jinja():
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'Test alert for {{owner}}; field {{field}}; Abc: {{_data["abc"]}}',
+        'alert_text_type': "alert_text_jinja",
+        'jinja_root_name': "_data"
+    }
+    match = {
+        '@timestamp': '2016-01-01',
+        'field': 'field_value',
+        'abc': 'abc from match',
+    }
+    alert = Alerter(rule)
+    alertsubject = alert.create_custom_title([match])
+    assert "Test alert for the_owner;" in alertsubject
+    assert "field field_value;" in alertsubject
+    assert "Abc: abc from match" in alertsubject


### PR DESCRIPTION
Opened to modification:
I re-used `alert_text_type` = `alert_text_jinja` to render `alert_subject`: reason is, I would not want to add another parameter that most users wouldn't know about.
And, I think that if you are using jinja2 templates for your alert_text, there's a lot of chance you would want to have the same configuration with alert_subject.

And it won't break configs, it will still check for alert_subject_args first.