### PR TITLE
Support character limit for chatwork

### DIFF
--- a/elastalert/alerters/chatwork.py
+++ b/elastalert/alerters/chatwork.py
@@ -28,9 +28,7 @@ class ChatworkAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
         if len(body) > 2047:
-            body = body[0:1950] + '\n *message was cropped according to chatwork embed description limits!* '
-        body += '```'
-
+            body = body[0:1950] + '\n *message was cropped according to chatwork embed description limits!*'
         headers = {'X-ChatWorkToken': self.chatwork_apikey}
         # set https proxy, if it was provided
         proxies = {'https': self.chatwork_proxy} if self.chatwork_proxy else None

--- a/tests/alerters/chatwork_test.py
+++ b/tests/alerters/chatwork_test.py
@@ -30,7 +30,7 @@ def test_chatwork(caplog):
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
+        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n```',
     }
 
     mock_post_request.assert_called_once_with(
@@ -67,7 +67,7 @@ def test_chatwork_proxy():
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
+        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n```',
     }
 
     mock_post_request.assert_called_once_with(
@@ -159,3 +159,37 @@ def test_chatwork_required_error(chatwork_apikey, chatwork_room_id, expected_dat
         assert expected_data == actual_data
     except Exception as ea:
         assert expected_data in str(ea)
+
+
+def test_chatwork_maxlength():
+    rule = {
+        'name': 'Test Chatwork Rule' + ('a' * 2069),
+        'type': 'any',
+        'chatwork_apikey': 'xxxx1',
+        'chatwork_room_id': 'xxxx2',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = ChatworkAlerter(rule)
+    match = {
+        '@timestamp': '2021-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'body': 'Test Chatwork Rule' + ('a' * 1932) +
+        '\n *message was cropped according to chatwork embed description limits!* ```'
+    }
+
+    mock_post_request.assert_called_once_with(
+        'https://api.chatwork.com/v2/rooms/xxxx2/messages',
+        params=mock.ANY,
+        headers={'X-ChatWorkToken': 'xxxx1'},
+        proxies=None,
+        auth=None
+    )
+
+    actual_data = mock_post_request.call_args_list[0][1]['params']
+    assert expected_data == actual_data

--- a/tests/alerters/chatwork_test.py
+++ b/tests/alerters/chatwork_test.py
@@ -30,7 +30,7 @@ def test_chatwork(caplog):
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n```',
+        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
     }
 
     mock_post_request.assert_called_once_with(
@@ -67,7 +67,7 @@ def test_chatwork_proxy():
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n```',
+        'body': 'Test Chatwork Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
     }
 
     mock_post_request.assert_called_once_with(
@@ -180,7 +180,7 @@ def test_chatwork_maxlength():
         alert.alert([match])
     expected_data = {
         'body': 'Test Chatwork Rule' + ('a' * 1932) +
-        '\n *message was cropped according to chatwork embed description limits!* ```'
+        '\n *message was cropped according to chatwork embed description limits!*'
     }
 
     mock_post_request.assert_called_once_with(


### PR DESCRIPTION
ChatWork found that the response body size limit was 2,048 bytes, so I decided not to set the excess value in the response body.