### PR TITLE
Support character limit for line notify

### DIFF
--- a/elastalert/alerters/line.py
+++ b/elastalert/alerters/line.py
@@ -1,7 +1,7 @@
 import requests
 from requests import RequestException
 
-from elastalert.alerts import Alerter
+from elastalert.alerts import Alerter, BasicMatchString
 from elastalert.util import EAException, elastalert_logger
 
 
@@ -14,7 +14,14 @@ class LineNotifyAlerter(Alerter):
         self.linenotify_access_token = self.rule.get("linenotify_access_token", None)
 
     def alert(self, matches):
-        body = self.create_alert_body(matches)
+        body = ''
+        for match in matches:
+            body += str(BasicMatchString(self.rule, match))
+            if len(matches) > 1:
+                body += '\n----------------------------------------\n'
+        if len(body) > 999:
+            body = body[0:900] + '\n *message was cropped according to line notify embed description limits!* '
+        body += '```'
         # post to Line Notify
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/elastalert/alerters/line.py
+++ b/elastalert/alerters/line.py
@@ -20,8 +20,7 @@ class LineNotifyAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
         if len(body) > 999:
-            body = body[0:900] + '\n *message was cropped according to line notify embed description limits!* '
-        body += '```'
+            body = body[0:900] + '\n *message was cropped according to line notify embed description limits!*'
         # post to Line Notify
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/tests/alerters/line_test.py
+++ b/tests/alerters/line_test.py
@@ -29,7 +29,7 @@ def test_line_notify(caplog):
         alert.alert([match])
 
     expected_data = {
-        'message': 'Test LineNotify Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n```'
+        'message': 'Test LineNotify Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n'
     }
 
     mock_post_request.assert_called_once_with(
@@ -135,7 +135,7 @@ def test_line_notify_maxlength():
 
     expected_data = {
         'message': 'Test LineNotify Rule' + ('a' * 880) +
-        '\n *message was cropped according to line notify embed description limits!* ```'
+        '\n *message was cropped according to line notify embed description limits!*'
     }
 
     mock_post_request.assert_called_once_with(


### PR DESCRIPTION
Line Notify found that the response body size limit was 1,000 bytes, so I decided not to set the excess value in the response body.