### PR TITLE
Redirecting warnings to logging module

### DIFF
--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -14,6 +14,7 @@ from elastalert import ElasticSearchClient
 from elastalert.auth import Auth
 
 logging.basicConfig()
+logging.captureWarnings(True)
 elastalert_logger = logging.getLogger('elastalert')
 
 


### PR DESCRIPTION
For logging, using `jsonformatter.JsonFormatter` without redirecting the warnings module to logging, the standard output is a mix of json and non json.