### PR TITLE
Added Chatwork proxy settings to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ## Other changes
 - [Tests] Add test code. Changed ubuntu version of Dockerfile-test from latest to 21.10. - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
 - Remove Python 2.x compatibility code - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
-
+- [Docs] Added Chatwork proxy settings to documentation - [#360](https://github.com/jertel/elastalert2/pull/360) - @nsano-rururu
 
 # 2.1.2
 ## Breaking changes

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1709,9 +1709,15 @@ Chatwork will send notification to a Chatwork application. The body of the notif
 
 Required:
 
-``chatwork_apikey``:  ChatWork API KEY.
+``chatwork_apikey``:  Chatwork API KEY.
 
 ``chatwork_room_id``: The ID of the room you are talking to in Chatwork. How to find the room ID is the part of the number after "rid" at the end of the URL of the browser.
+
+``chatwork_proxy``: By default ElastAlert 2 will not use a network proxy to send notifications to Chatwork. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
+
+``chatwork_proxy_login``: The Chatwork proxy auth username.
+
+``chatwork_proxy_pass``: The Chatwork proxy auth password.
 
 Example usage::
 


### PR DESCRIPTION
## Description

I forgot to add the chatwork proxy setting to the docs, so I added it.

chatwork_proxy
chatwork_proxy_login
chatwork_proxy_pass

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
