### PR TITLE
Add settings to schema.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ## Other changes
 - [Tests] Add test code. Changed ubuntu version of Dockerfile-test from latest to 21.10. - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
 - Remove Python 2.x compatibility code - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
-
+- Add settings to schema.yaml(Chatwork proxy, Dingtalk proxy) - [#361](https://github.com/jertel/elastalert2/pull/361) - @nsano-rururu
 
 # 2.1.2
 ## Breaking changes

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -305,6 +305,9 @@ properties:
   ### Chatwork
   chatwork_apikey: {type: string}
   chatwork_room_id: {type: string}
+  chatwork_proxy: {type: string}
+  chatwork_proxy_login: {type: string}
+  chatwork_proxy_pass: {type: string}
 
   ### Command
   command: *arrayOfString
@@ -322,6 +325,9 @@ properties:
   dingtalk_single_title: {type: string}
   dingtalk_single_url: {type: string}
   dingtalk_btn_orientation: {type: string}
+  dingtalk_proxy: {type: string}
+  dingtalk_proxy_login: {type: string}
+  dingtalk_proxy_pass: {type: string}
 
   ## Discord
   discord_webhook_url: {type: string}


### PR DESCRIPTION


## Description

Add settings to schema.yaml

- chatwork_proxy
- chatwork_proxy_login
- chatwork_proxy_pass
- dingtalk_proxy
- dingtalk_proxy_login
- dingtalk_proxy_pass

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
