### PR TITLE
Tidy Twilio documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Tests] Add test code. Changed ubuntu version of Dockerfile-test from latest to 21.10. - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
 - Remove Python 2.x compatibility code - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
 - [Docs] Added Chatwork proxy settings to documentation - [#360](https://github.com/jertel/elastalert2/pull/360) - @nsano-rururu
+- [Docs] Tidy Twilio alerter documentation - [#363](https://github.com/jertel/elastalert2/pull/363) - @ferozsalam
 - Add settings to schema.yaml(Chatwork proxy, Dingtalk proxy) - [#361](https://github.com/jertel/elastalert2/pull/361) - @nsano-rururu
 
 # 2.1.2

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2859,28 +2859,32 @@ Example usage::
 Twilio
 ~~~~~~
 
-Twilio alerter will trigger an incident to a mobile phone as an sms from your twilio phone number. The sms will contain the alert name. You may use either twilio SMS or twilio copilot
-to send the message, controlled by the ``twilio_use_copilot`` option.
+The Twilio alerter will send an alert to a mobile phone as an SMS from your Twilio
+phone number. The SMS will contain the alert name. You may use either Twilio SMS
+or Twilio Copilot to send the message, controlled by the ``twilio_use_copilot``
+option.
 
-Note that when twilio copilot *is* used the ``twilio_message_service_sid`` option is required. Likewise, when *not* using twilio copilot, the ``twilio_from_number`` option is required.
+Note that when Twilio Copilot *is* used the ``twilio_message_service_sid``
+option is required. Likewise, when *not* using Twilio Copilot, the
+``twilio_from_number`` option is required.
 
 The alerter requires the following options:
 
-``twilio_account_sid``: This is sid of your twilio account.
+``twilio_account_sid``: The SID of your Twilio account.
 
-``twilio_auth_token``: Auth token assosiated with your twilio account.
+``twilio_auth_token``: Auth token associated with your Twilio account.
 
-``twilio_to_number``: The phone number where you would like send the notification.
+``twilio_to_number``: The phone number where you would like to send the alert.
 
 Either one of
- * ``twilio_from_number``: Your twilio phone number from which message will be sent.
- * ``twilio_message_service_sid``: The SID of your twilio message service.
+ * ``twilio_from_number``: The Twilio phone number from which the alert will be sent.
+ * ``twilio_message_service_sid``: The SID of your Twilio message service.
 
 Optional:
 
-``twilio_use_copilot``: Whether or not to use twilio copilot, False by default.
+``twilio_use_copilot``: Whether or not to use Twilio Copilot, False by default.
 
-Example With Copilot usage::
+Example with Copilot usage::
 
     alert:
       - "twilio"
@@ -2890,7 +2894,7 @@ Example With Copilot usage::
     twilio_account_sid: "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"
     twilio_message_service_sid: "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"
 
-Example With SMS usage::
+Example with SMS usage::
 
     alert:
       - "twilio"


### PR DESCRIPTION
## Description

Minor tidiness tweaks to the Twilio alerter documentation.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Unit tests and `make test-dockerr` don't apply as it's a pure docs update.