### PR TITLE
Update Jira styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Remove Python 2.x compatibility code - [#354](https://github.com/jertel/elastalert2/pull/354) - @nsano-rururu
 - [Docs] Added Chatwork proxy settings to documentation - [#360](https://github.com/jertel/elastalert2/pull/360) - @nsano-rururu
 - [Docs] Tidy Twilio alerter documentation - [#363](https://github.com/jertel/elastalert2/pull/363) - @ferozsalam
+- [Docs] Update mentions of JIRA to Jira - [#365](https://github.com/jertel/elastalert2/pull/365) - @ferozsalam
 - Add settings to schema.yaml(Chatwork proxy, Dingtalk proxy) - [#361](https://github.com/jertel/elastalert2/pull/361) - @nsano-rururu
 
 # 2.1.2

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -41,7 +41,7 @@ Currently, we have support built in for these alert types:
 - Gitter
 - GoogleChat
 - HTTP POST
-- JIRA
+- Jira
 - Line Notify
 - Mattermost
 - Microsoft Teams

--- a/docs/source/recipes/adding_alerts.rst
+++ b/docs/source/recipes/adding_alerts.rst
@@ -34,7 +34,7 @@ should be in the rule configuration file and can be accessed here.
 
 ``self.pipeline``: This is a dictionary object that serves to transfer information between alerts. When an alert is triggered,
 a new empty pipeline object will be created and each alerter can add or receive information from it. Note that alerters
-are called in the order they are defined in the rule file. For example, the JIRA alerter will add its ticket number
+are called in the order they are defined in the rule file. For example, the Jira alerter will add its ticket number
 to the pipeline and the email alerter will add that link if it's present in the pipeline.
 
 alert(self, match):

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -385,7 +385,7 @@ Then, assuming an aggregation window of 10 minutes, if you receive the following
 
 This should result in 2 alerts: One containing alice's two events, sent at ``2016-09-20T00:10:00`` and one containing bob's one event sent at ``2016-09-20T00:16:00``
 
-For aggregations, there can sometimes be a large number of documents present in the viewing medium (email, jira ticket, etc..). If you set the ``summary_table_fields`` field, ElastAlert 2 will provide a summary of the specified fields from all the results.
+For aggregations, there can sometimes be a large number of documents present in the viewing medium (email, Jira ticket, etc..). If you set the ``summary_table_fields`` field, ElastAlert 2 will provide a summary of the specified fields from all the results.
 
 For example, if you wish to summarize the usernames and event_types that appear in the documents so that you can see the most relevant fields at a quick glance, you can set::
 
@@ -1398,7 +1398,7 @@ for each alerter.
 Alert Subject
 ~~~~~~~~~~~~~
 
-E-mail subjects, JIRA issue summaries, PagerDuty alerts, or any alerter that has a "subject" can be customized by adding an ``alert_subject``
+E-mail subjects, Jira issue summaries, PagerDuty alerts, or any alerter that has a "subject" can be customized by adding an ``alert_subject``
 that contains a custom summary.
 It can be further formatted using standard Python formatting syntax::
 
@@ -2065,24 +2065,24 @@ Example usage::
     http_post_headers:
       authorization: Basic 123dr3234
 
-JIRA
+Jira
 ~~~~
 
-The JIRA alerter will open a ticket on jira whenever an alert is triggered. You must have a service account for ElastAlert to connect with.
+The Jira alerter will open a ticket on Jira whenever an alert is triggered. You must have a service account for ElastAlert to connect with.
 The credentials of the service account are loaded from a separate file. The ticket number will be written to the alert pipeline, and if it
 is followed by an email alerter, a link will be included in the email.
 
 This alert requires four additional options:
 
-``jira_server``: The hostname of the JIRA server.
+``jira_server``: The hostname of the Jira server.
 
 ``jira_project``: The project to open the ticket under.
 
 ``jira_issuetype``: The type of issue that the ticket will be filed as. Note that this is case sensitive.
 
-``jira_account_file``: The path to the file which contains JIRA account credentials.
+``jira_account_file``: The path to the file which contains Jira account credentials.
 
-For an example JIRA account file, see ``examples/rules/jira_acct.yaml``. The account file is also yaml formatted and must contain two fields:
+For an example Jira account file, see ``examples/rules/jira_acct.yaml``. The account file is also yaml formatted and must contain two fields:
 
 ``user``: The username.
 
@@ -2096,16 +2096,16 @@ Optional:
 
 ``jira_components``: The name of the component or components to set the ticket to. This can be a single string or a list of strings.
 
-``jira_description``: Similar to ``alert_text``, this text is prepended to the JIRA description.
+``jira_description``: Similar to ``alert_text``, this text is prepended to the Jira description.
 
-``jira_label``: The label or labels to add to the JIRA ticket.  This can be a single string or a list of strings. This is provided for backwards compatibility and will eventually be deprecated. It is preferable to use the plural ``jira_labels`` instead.
+``jira_label``: The label or labels to add to the Jira ticket.  This can be a single string or a list of strings. This is provided for backwards compatibility and will eventually be deprecated. It is preferable to use the plural ``jira_labels`` instead.
 
-``jira_labels``: The label or labels to add to the JIRA ticket.  This can be a single string or a list of strings.
+``jira_labels``: The label or labels to add to the Jira ticket.  This can be a single string or a list of strings.
 
-``jira_priority``: The index of the priority to set the issue to. In the JIRA dropdown for priorities, 0 would represent the first priority,
+``jira_priority``: The index of the priority to set the issue to. In the Jira dropdown for priorities, 0 would represent the first priority,
 1 the 2nd, etc.
 
-``jira_watchers``: A list of user names to add as watchers on a JIRA ticket. This can be a single string or a list of strings.
+``jira_watchers``: A list of user names to add as watchers on a Jira ticket. This can be a single string or a list of strings.
 
 ``jira_bump_tickets``: If true, ElastAlert search for existing tickets newer than ``jira_max_age`` and comment on the ticket with
 information about the alert instead of opening another ticket. ElastAlert finds the existing ticket by searching by summary. If the
@@ -2114,7 +2114,7 @@ the two summaries must be exact matches, except by setting ``jira_ignore_in_titl
 For example, if the custom subject is "foo occured at bar", and "foo" is the value field X in the match, you can set ``jira_ignore_in_title``
 to "X" and it will only bump tickets with "bar" in the subject. Defaults to false.
 
-``jira_ignore_in_title``: ElastAlert will attempt to remove the value for this field from the JIRA subject when searching for tickets to bump.
+``jira_ignore_in_title``: ElastAlert will attempt to remove the value for this field from the Jira subject when searching for tickets to bump.
 See ``jira_bump_tickets`` description above for an example.
 
 ``jira_max_age``: If ``jira_bump_tickets`` is true, the maximum age of a ticket, in days, such that ElastAlert will comment on the ticket
@@ -2145,7 +2145,7 @@ Example usage::
 
     jira_bump_only: true
 
-``jira_transition_to``: If ``jira_bump_tickets`` is true, Transition this ticket to the given Status when bumping. Must match the text of your JIRA implementation's Status field.
+``jira_transition_to``: If ``jira_bump_tickets`` is true, Transition this ticket to the given Status when bumping. Must match the text of your Jira implementation's Status field.
 
 Example usage::
 
@@ -2158,9 +2158,9 @@ It only applies if ``jira_bump_tickets`` is true. Default is 0 days.
 
 Arbitrary Jira fields:
 
-ElastAlert supports setting any arbitrary JIRA field that your jira issue supports. For example, if you had a custom field, called "Affected User", you can set it by providing that field name in ``snake_case`` prefixed with ``jira_``.  These fields can contain primitive strings or arrays of strings. Note that when you create a custom field in your JIRA server, internally, the field is represented as ``customfield_1111``. In elastalert, you may refer to either the public facing name OR the internal representation.
+ElastAlert supports setting any arbitrary Jira field that your Jira issue supports. For example, if you had a custom field, called "Affected User", you can set it by providing that field name in ``snake_case`` prefixed with ``jira_``.  These fields can contain primitive strings or arrays of strings. Note that when you create a custom field in your Jira server, internally, the field is represented as ``customfield_1111``. In elastalert, you may refer to either the public facing name OR the internal representation.
 
-In addition, if you would like to use a field in the alert as the value for a custom JIRA field, use the field name plus a # symbol in front. For example, if you wanted to set a custom JIRA field called "user" to the value of the field "username" from the match, you would use the following.
+In addition, if you would like to use a field in the alert as the value for a custom Jira field, use the field name plus a # symbol in front. For example, if you wanted to set a custom Jira field called "user" to the value of the field "username" from the match, you would use the following.
 
 Example::
 

--- a/elastalert/alerters/email.py
+++ b/elastalert/alerters/email.py
@@ -48,10 +48,10 @@ class EmailAlerter(Alerter):
     def alert(self, matches):
         body = self.create_alert_body(matches)
 
-        # Add JIRA ticket if it exists
+        # Add Jira ticket if it exists
         if self.pipeline is not None and 'jira_ticket' in self.pipeline:
             url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
-            body += '\nJIRA ticket: %s' % (url)
+            body += '\nJira ticket: %s' % (url)
 
         to_addr = self.rule['email']
         if 'email_from_field' in self.rule:

--- a/elastalert/alerters/jira.py
+++ b/elastalert/alerters/jira.py
@@ -46,7 +46,7 @@ class JiraAlerter(Alerter):
         'jira_watchers',
     ]
 
-    # Some built-in jira types that can be used as custom fields require special handling
+    # Some built-in Jira types that can be used as custom fields require special handling
     # Here is a sample of one of them:
     # {"id":"customfield_12807","name":"My Custom Field","custom":true,"orderable":true,"navigable":true,"searchable":true,
     # "clauseNames":["cf[12807]","My Custom Field"],"schema":{"type":"array","items":"string",
@@ -109,7 +109,7 @@ class JiraAlerter(Alerter):
             self.get_arbitrary_fields()
         except JIRAError as e:
             # JIRAError may contain HTML, pass along only first 1024 chars
-            raise EAException("Error connecting to JIRA: %s" % (str(e)[:1024])).with_traceback(sys.exc_info()[2])
+            raise EAException("Error connecting to Jira: %s" % (str(e)[:1024])).with_traceback(sys.exc_info()[2])
 
         self.set_priority()
 
@@ -147,7 +147,7 @@ class JiraAlerter(Alerter):
     def set_jira_arg(self, jira_field, value, fields):
         # Remove the jira_ part.  Convert underscores to spaces
         normalized_jira_field = jira_field[5:].replace('_', ' ').lower()
-        # All jira fields should be found in the 'id' or the 'name' field. Therefore, try both just in case
+        # All Jira fields should be found in the 'id' or the 'name' field. Therefore, try both just in case
         for identifier in ['name', 'id']:
             field = next((f for f in fields if normalized_jira_field == f[identifier].replace('_', ' ').lower()), None)
             if field:
@@ -173,7 +173,7 @@ class JiraAlerter(Alerter):
             array_items = field['schema']['items']
             # Simple string types
             if array_items in ['string', 'date', 'datetime']:
-                # Special case for multi-select custom types (the JIRA metadata says that these are strings, but
+                # Special case for multi-select custom types (the Jira metadata says that these are strings, but
                 # in reality, they are required to be provided as an object.
                 if 'custom' in field['schema'] and field['schema']['custom'] in self.custom_string_types_with_special_handling:
                     self.jira_args[arg_name] = [{'value': v} for v in value]
@@ -193,7 +193,7 @@ class JiraAlerter(Alerter):
         else:
             # Simple string types
             if arg_type in ['string', 'date', 'datetime']:
-                # Special case for custom types (the JIRA metadata says that these are strings, but
+                # Special case for custom types (the Jira metadata says that these are strings, but
                 # in reality, they are required to be provided as an object.
                 if 'custom' in field['schema'] and field['schema']['custom'] in self.custom_string_types_with_special_handling:
                     self.jira_args[arg_name] = {'value': value}
@@ -214,8 +214,8 @@ class JiraAlerter(Alerter):
 
         for jira_field, value in self.rule.items():
             # If we find a field that is not covered by the set that we are aware of, it means it is either:
-            # 1. A built-in supported field in JIRA that we don't have on our radar
-            # 2. A custom field that a JIRA admin has configured
+            # 1. A built-in supported field in Jira that we don't have on our radar
+            # 2. A custom field that a Jira admin has configured
             if jira_field.startswith('jira_') and jira_field not in self.known_field_list and str(value)[:1] != '#':
                 self.set_jira_arg(jira_field, value, self.jira_fields)
             if jira_field.startswith('jira_') and jira_field not in self.known_field_list and str(value)[:1] == '#':
@@ -261,7 +261,7 @@ class JiraAlerter(Alerter):
         try:
             issues = self.client.search_issues(jql)
         except JIRAError as e:
-            elastalert_logger.exception("Error while searching for JIRA ticket using jql '%s': %s" % (jql, e))
+            elastalert_logger.exception("Error while searching for Jira ticket using jql '%s': %s" % (jql, e))
             return None
 
         if len(issues):
@@ -346,7 +346,7 @@ class JiraAlerter(Alerter):
                             )).with_traceback(sys.exc_info()[2])
 
         except JIRAError as e:
-            raise EAException("Error creating JIRA ticket using jira_args (%s): %s" % (self.jira_args, e))
+            raise EAException("Error creating Jira ticket using jira_args (%s): %s" % (self.jira_args, e))
         elastalert_logger.info("Opened Jira ticket: %s" % (self.issue))
 
         if self.pipeline is not None:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -182,7 +182,7 @@ class Alerter(object):
         return {'type': 'Unknown'}
 
     def create_title(self, matches):
-        """ Creates custom alert title to be used, e.g. as an e-mail subject or JIRA issue summary.
+        """ Creates custom alert title to be used, e.g. as an e-mail subject or Jira issue summary.
 
         :param matches: A list of dictionaries of relevant information to the alert.
         """

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -120,7 +120,7 @@ class RulesLoader(object):
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list
-    # For example, Jira goes before email so the ticket # will be added to the resulting email.
+    # For example, jira goes before email so the ticket # will be added to the resulting email.
     alerts_order = {
         'jira': 0,
         'email': 1

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -120,7 +120,7 @@ class RulesLoader(object):
     }
 
     # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list
-    # For example, jira goes before email so the ticket # will be added to the resulting email.
+    # For example, Jira goes before email so the ticket # will be added to the resulting email.
     alerts_order = {
         'jira': 0,
         'email': 1

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -385,7 +385,7 @@ properties:
   http_post_ignore_ssl_errors: {type: boolean}
   http_post_timeout: {type: integer}
 
-  ### JIRA
+  ### Jira
   jira_server: {type: string}
   jira_project: {type: string}
   jira_issuetype: {type: string}

--- a/tests/alerters/jira_test.py
+++ b/tests/alerters/jira_test.py
@@ -129,7 +129,7 @@ def test_jira(caplog):
     user, level, message = caplog.record_tuples[3]
     assert 'elastalert' in user
     assert logging.ERROR == level
-    assert 'Error while searching for JIRA ticket using jql' in message
+    assert 'Error while searching for Jira ticket using jql' in message
 
     # Only bump after 3d of inactivity
     rule['jira_bump_after_inactivity'] = 3
@@ -299,7 +299,7 @@ def test_jira_arbitrary_field_support():
     assert mock_jira.mock_calls[:6] == expected
     assert mock_jira.mock_calls[3][2]['description'].startswith(description_txt)
 
-    # Reference an arbitrary string field that is not defined on the JIRA server
+    # Reference an arbitrary string field that is not defined on the Jira server
     rule['jira_nonexistent_field'] = 'nonexistent field value'
 
     with mock.patch('elastalert.alerters.jira.JIRA') as mock_jira, \


### PR DESCRIPTION
## Description

From late 2017 onwards, JIRA was [rebranded](https://community.atlassian.com/t5/Feedback-Forum-articles/A-new-look-for-Atlassian/ba-p/638077) as Jira - this updates
the ElastAlert documentation in line with that.

In some places we were also using all lowercase 'jira' in the docs,
so I've updated those too.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

No unit tests - I have made no functional additions or changes, just changed some spellings.
