### PR TITLE
Fix hyperlinks in Datadog documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Docs] Added Chatwork proxy settings to documentation - [#360](https://github.com/jertel/elastalert2/pull/360) - @nsano-rururu
 - Add settings to schema.yaml(Chatwork proxy, Dingtalk proxy) - [#361](https://github.com/jertel/elastalert2/pull/361) - @nsano-rururu
 - [Docs] Tidy Twilio alerter documentation - [#363](https://github.com/jertel/elastalert2/pull/363) - @ferozsalam
+- [Docs] Tidy Datadog alerter documentation - [#380](https://github.com/jertel/elastalert2/pull/380) - @ferozsalam
 - [Tests] Improve opsgenie test code coverage - [#364](https://github.com/jertel/elastalert2/pull/364) - @nsano-rururu
 - [Docs] Update mentions of JIRA to Jira - [#365](https://github.com/jertel/elastalert2/pull/365) - @ferozsalam
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1774,14 +1774,14 @@ Example usage using new-style format::
 Datadog
 ~~~~~~~
 
-This alert will create a [Datadog Event](https://docs.datadoghq.com/events/). Events are limited to 4000 characters. If an event is sent that contains
+This alert will create a `Datadog Event`_. Events are limited to 4000 characters. If an event is sent that contains
 a message that is longer than 4000 characters, only his first 4000 characters will be displayed.
 
 This alert requires two additional options:
 
-``datadog_api_key``: [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
+``datadog_api_key``: `Datadog API key`_
 
-``datadog_app_key``: [Datadog application key](https://docs.datadoghq."com/account_management/api-app-keys/#application-keys)
+``datadog_app_key``: `Datadog application key`_
 
 Example usage::
 
@@ -1789,6 +1789,10 @@ Example usage::
       - "datadog"
     datadog_api_key: "Datadog API Key"
     datadog_app_key: "Datadog APP Key"
+
+.. _`Datadog Event`: https://docs.datadoghq.com/events/
+.. _`Datadog API key`: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+.. _`Datadog application key`: https://docs.datadoghq.com/account_management/api-app-keys/#application-keys
 
 Debug
 ~~~~~


### PR DESCRIPTION
## Description

The links in the Datadog docs were structured as Markdown when they should have been structured
as reStructuredText

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Docs change alone, so no unit tests!