### PR TITLE
Adds metric_format_string config to Metric Aggregation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## New features
 - [Kubernetes] Adding Image Pull Secret to Helm Chart - [#370](https://github.com/jertel/elastalert2/pull/370) - @robrankin
 - Apply percentage_format_string to match_body percentage value; will appear in new percentage_formatted key - [#387](https://github.com/jertel/elastalert2/pull/387) - @iamxeph
+- Add metric_format_string optional configuration for Metric Aggregation to format aggregated value - [#](https://github.com/jertel/elastalert2/pull/) - @iamxeph
 - Add support for Kibana 7.14 for Kibana Discover - [#392](https://github.com/jertel/elastalert2/pull/392) - @nsano-rururu
 
 ## Other changes

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1263,6 +1263,10 @@ allign with the time elastalert runs, (This both avoid calculations on partial d
 See: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#_offset for a
 more comprehensive explaination.
 
+``metric_format_string``: An optional format string applies to the aggregated metric value in the alert match text and match_body. This adds 'metric_{metric_agg_key}_formatted' value to the match_body in addition to raw, unformatted 'metric_{metric_agg_key}' value so that you can use the values for ``alert_subject_args`` and ``alert_text_args``. Must be a valid python format string. Both format() and %-formatted syntax works. For example, "{:.2%}" will format '0.966666667' to '96.67%', and "%.2f" will format '0.966666667' to '0.97'.
+See: https://docs.python.org/3.4/library/string.html#format-specification-mini-language
+
+
 Spike Aggregation
 ~~~~~~~~~~~~~~~~~~
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1069,15 +1069,10 @@ class MetricAggregationRule(BaseAggregationRule):
 
     def get_match_str(self, match):
         metric_format_string = self.rules.get('metric_format_string', None)
-        if metric_format_string is not None:
-            if (metric_format_string.startswith('{')):
-                metric_formatted = metric_format_string.format(match[self.metric_key])
-            else:
-                metric_formatted = metric_format_string % (match[self.metric_key])
         message = 'Threshold violation, %s:%s %s (min: %s max : %s) \n\n' % (
             self.rules['metric_agg_type'],
             self.rules['metric_agg_key'],
-            metric_formatted if metric_format_string else match[self.metric_key],
+            self.format_string(metric_format_string, match[self.metric_key]) if metric_format_string else match[self.metric_key],
             self.rules.get('min_threshold'),
             self.rules.get('max_threshold')
         )
@@ -1103,10 +1098,7 @@ class MetricAggregationRule(BaseAggregationRule):
                          self.metric_key: metric_val}
                 metric_format_string = self.rules.get('metric_format_string', None)
                 if metric_format_string is not None:
-                    if (metric_format_string.startswith('{')):
-                        match[self.metric_key +'_formatted'] = metric_format_string.format(metric_val)
-                    else:
-                        match[self.metric_key +'_formatted'] = metric_format_string % (metric_val)
+                    match[self.metric_key +'_formatted'] = self.format_string(metric_format_string, metric_val)
                 if query_key is not None:
                     match = expand_string_into_dict(match, self.rules['query_key'], query_key)
                 self.add_match(match)
@@ -1147,6 +1139,12 @@ class MetricAggregationRule(BaseAggregationRule):
         if 'min_threshold' in self.rules and metric_value < self.rules['min_threshold']:
             return True
         return False
+
+    def format_string(self, metric_format_string, target_string):
+        if (metric_format_string.startswith('{')):
+            return metric_format_string.format(target_string)
+        else:
+            return metric_format_string % (target_string)
 
 
 class SpikeMetricAggregationRule(BaseAggregationRule, SpikeRule):

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1140,11 +1140,11 @@ class MetricAggregationRule(BaseAggregationRule):
             return True
         return False
 
-    def format_string(self, metric_format_string, target_string):
-        if (metric_format_string.startswith('{')):
-            return metric_format_string.format(target_string)
+    def format_string(self, format_config, target_value):
+        if (format_config.startswith('{')):
+            return format_config.format(target_value)
         else:
-            return metric_format_string % (target_string)
+            return format_config % (target_value)
 
 
 class SpikeMetricAggregationRule(BaseAggregationRule, SpikeRule):

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -1163,6 +1163,24 @@ def test_metric_aggregation():
     rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.95}})
     assert len(rule.matches) == 2
 
+    rule = MetricAggregationRule(rules)
+    rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
+    assert '0.966666667' in rule.get_match_str(rule.matches[0])
+    assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert 'metric_cpu_pct_avg_formatted' not in rule.matches[0]
+    rules['metric_format_string'] = '{:.2%}'
+    rule = MetricAggregationRule(rules)
+    rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
+    assert '96.67%' in rule.get_match_str(rule.matches[0])
+    assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert rule.matches[0]['metric_cpu_pct_avg_formatted'] == '96.67%'
+    rules['metric_format_string'] = '%.2f'
+    rule = MetricAggregationRule(rules)
+    rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
+    assert '0.97' in rule.get_match_str(rule.matches[0])
+    assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert rule.matches[0]['metric_cpu_pct_avg_formatted'] == '0.97'
+
     rules['query_key'] = 'subdict'
     rule = MetricAggregationRule(rules)
     rule.check_matches(datetime.datetime.now(), 'qk_val', {'metric_cpu_pct_avg': {'value': 0.95}})


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->
This PR adds metric_format_string optional configuration to Metric Aggregation rule. 'metric_format_string' formats match_body's metric_{metric_agg_key} value supporting both format() and %-formatted syntax.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->

After this gets merged, I am going to change 'percentage_format_string' of Percentage Aggregation rule to support format() syntax in addition to old %-formatted syntax to make both 'metric_format_string' and 'percentage_format_string' have consistency.
