### PR TITLE
Allowing users to customize timestamp format printed by pretty_ts() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add support for Kibana 7.14 for Kibana Discover - [#392](https://github.com/jertel/elastalert2/pull/392) - @nsano-rururu
 - Add metric_format_string optional configuration for Metric Aggregation to format aggregated value - [#399](https://github.com/jertel/elastalert2/pull/399) - @iamxeph
 - Make percentage_format_string support format() syntax in addition to old %-formatted syntax - [#403](https://github.com/jertel/elastalert2/pull/403) - @iamxeph
+- Add custom_pretty_ts_format option to provides a way to define custom format of timestamps printed by pretty_ts() function - [#407](https://github.com/jertel/elastalert2/pull/407) - @perceptron01
 
 ## Other changes
 - [Tests] Improve test code coverage - [#331](https://github.com/jertel/elastalert2/pull/331) - @nsano-rururu

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -230,6 +230,15 @@ The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticse
 
 ``jinja_template_path``: When using a Jinja template, specify filesystem path to template, this overrides the default behaviour of using alert_text as the template.
 
+``custom_pretty_ts_format``: This option provides a way to define custom format of timestamps printed in log messages and in alert messages.
+If this option is not set, default timestamp format ('%Y-%m-%d %H:%M %Z') will be used. (Optional, string, default None)
+
+Example usage and resulting formatted timestamps::
+
+    (not set; default)                               -> '2021-08-16 21:38 JST'
+    custom_pretty_ts_format: '%Y-%m-%d %H:%M %z'     -> '2021-08-16 21:38 +0900'
+    custom_pretty_ts_format: '%Y-%m-%d %H:%M'        -> '2021-08-16 21:38'
+
 Logging
 -------
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -78,6 +78,7 @@ def load_conf(args, defaults=None, overwrites=None):
     conf.setdefault('disable_rules_on_error', True)
     conf.setdefault('scan_subdirectories', True)
     conf.setdefault('rules_loader', 'file')
+    conf.setdefault('custum_pretty_ts_format', None)
 
     # Convert run_every, buffer_time into a timedelta object
     try:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -235,6 +235,7 @@ properties:
   kibana_dashboard: {type: string}
   use_kibana_dashboard: {type: string}
   use_local_time: {type: boolean}
+  custom_pretty_ts_format: {type: string}
   match_enhancements: {type: array, items: {type: string}}
   query_key: *arrayOfString
   replace_dots_in_field_names: {type: boolean}

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -199,7 +199,7 @@ def inc_ts(timestamp, milliseconds=1):
     return dt_to_ts(dt)
 
 
-def pretty_ts(timestamp, tz=True):
+def pretty_ts(timestamp, tz=True, ts_format=None):
     """Pretty-format the given timestamp (to be printed or logged hereafter).
     If tz, the timestamp will be converted to local time.
     Format: YYYY-MM-DD HH:MM TZ"""
@@ -208,7 +208,10 @@ def pretty_ts(timestamp, tz=True):
         dt = ts_to_dt(timestamp)
     if tz:
         dt = dt.astimezone(dateutil.tz.tzlocal())
-    return dt.strftime('%Y-%m-%d %H:%M %z')
+    if ts_format is None:
+        return dt.strftime('%Y-%m-%d %H:%M %Z')
+    else:
+        return dt.strftime(ts_format)
 
 
 def ts_add(ts, td):

--- a/examples/config.yaml.example
+++ b/examples/config.yaml.example
@@ -72,6 +72,10 @@ writeback_index: elastalert_status
 alert_time_limit:
   days: 2
 
+# Optional timestamp format.
+# ElastAlert will print timestamps in alert messages and in log messages using this format.
+#custom_pretty_ts_format: '%Y-%m-%d %H:%M'
+
 # Custom logging configuration
 # If you want to setup your own logging configuration to log into
 # files as well or to Logstash and/or modify log levels, use

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1463,5 +1463,5 @@ def test_time_enhancement(ea):
         'somefield': 'foobarbaz'
     }
     te.process(match)
-    excepted = '2021-01-01 00:00 +0000'
+    excepted = '2021-01-01 00:00 UTC'
     assert match['@timestamp'] == excepted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,8 @@ def ea():
             'max_query_size': 10000,
             'old_query_limit': datetime.timedelta(weeks=1),
             'disable_rules_on_error': False,
-            'scroll_keepalive': '30s'}
+            'scroll_keepalive': '30s',
+            'custom_pretty_ts_format': '%Y-%m-%d %H:%M'}
     elastalert.util.elasticsearch_client = mock_es_client
     conf['rules_loader'] = mock_rule_loader(conf)
     elastalert.elastalert.elasticsearch_client = mock_es_client
@@ -223,7 +224,8 @@ def ea_sixsix():
             'max_query_size': 10000,
             'old_query_limit': datetime.timedelta(weeks=1),
             'disable_rules_on_error': False,
-            'scroll_keepalive': '30s'}
+            'scroll_keepalive': '30s',
+            'custom_pretty_ts_format': '%Y-%m-%d %H:%M'}
     conf['rules_loader'] = mock_rule_loader(conf)
     elastalert.elastalert.elasticsearch_client = mock_es_sixsix_client
     elastalert.util.elasticsearch_client = mock_es_sixsix_client

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -36,6 +36,7 @@ from elastalert.util import ts_utc_to_tz
 from elastalert.util import expand_string_into_dict
 from elastalert.util import unixms_to_dt
 from elastalert.util import format_string
+from elastalert.util import pretty_ts
 
 
 @pytest.mark.parametrize('spec, expected_delta', [
@@ -511,3 +512,10 @@ def test_format_string():
     assert format_string('%.2f', target) == expected_percent_formatting
     expected_str_formatting = '96.67%'
     assert format_string('{:.2%}', target) == expected_str_formatting
+
+
+def test_pretty_ts():
+    ts = datetime(year=2021, month=8, day=16, hour=16, minute=35, second=5)
+    assert '2021-08-16 16:35 UTC' == pretty_ts(ts)
+    assert '2021-08-16 16:35 ' == pretty_ts(ts, False)
+    assert '2021-08-16 16:35 +0000' == pretty_ts(ts, ts_format='%Y-%m-%d %H:%M %z')


### PR DESCRIPTION
## Description

This PR adds optional configuration of `custom_pretty_ts_format`, which provides a way to define custom format of timestamps printed in log messages and in alert messages.This function is realized by modifying pretty_ts() function in `util.py` and its related components. 
`custom_pretty_ts_format` is expected to be specified like this in `config.yaml`.
```
custom_pretty_ts_format: '%Y-%m-%d %H:%M'
```
## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments
~CHANGELOG.md will be updated after the number of PR is fixed.~
Updating CHANGELOG.md has been done.