### PR TITLE
Fixed typo in default setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 - None
 
 
+# 2.x.x
+
+## Breaking changes
+- None
+
+## New features
+- None
+
+## Other changes
+- Fixed typo in default setting accidentally introduced in [#407](https://github.com/jertel/elastalert2/pull/407)  - [#413](https://github.com/jertel/elastalert2/pull/413) - @perceptron01
+
 # 2.2.1
 
 ## Breaking changes

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -78,7 +78,7 @@ def load_conf(args, defaults=None, overwrites=None):
     conf.setdefault('disable_rules_on_error', True)
     conf.setdefault('scan_subdirectories', True)
     conf.setdefault('rules_loader', 'file')
-    conf.setdefault('custum_pretty_ts_format', None)
+    conf.setdefault('custom_pretty_ts_format', None)
 
     # Convert run_every, buffer_time into a timedelta object
     try:


### PR DESCRIPTION
## Description

Fixed typo in default setting accidentally introduced in [#407](https://github.com/jertel/elastalert2/pull/407), which is reported in https://github.com/jertel/elastalert2/issues/411

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments
- Unit test is not included in this PR because this PR just fix a single typo in default config for existing function.
- Documentation is not updated because fixing this typo does not change the behavior of the app.
