### PR TITLE
Fix saving option only using days argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ## Other changes
 - Fixed typo in default setting accidentally introduced in [#407](https://github.com/jertel/elastalert2/pull/407)  - [#413](https://github.com/jertel/elastalert2/pull/413) - @perceptron01
+- Fix saving feature which was ignoring --start/--end, and storing no content with default --days value to 0
 
 # 2.2.1
 

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -42,15 +42,121 @@ def print_terms(terms, parent):
 
 
 class MockElastAlerter(object):
-    def __init__(self):
+    def _parse_args(self, args: list) -> argparse.Namespace:
+        """Uses args to run the various components of MockElastAlerter such as loading the file, saving data, loading data"""
+        parser = argparse.ArgumentParser(description="Validate a rule configuration")
+        parser.add_argument(
+            "file", metavar="rule", type=str, help="rule configuration filename"
+        )
+        parser.add_argument(
+            "--schema-only",
+            action="store_true",
+            help="Show only schema errors; do not run query",
+        )
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=0,
+            action="store",
+            help="Query the previous N days with this rule",
+        )
+        parser.add_argument(
+            "--start",
+            dest="start",
+            help="YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.",
+        )
+        parser.add_argument(
+            "--end",
+            dest="end",
+            help="YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present) "
+            'Use "NOW" to start from current time. (Default: present)',
+        )
+        parser.add_argument(
+            "--stop-error",
+            action="store_true",
+            help="Stop the entire test right after the first error",
+        )
+        parser.add_argument(
+            "--formatted-output",
+            action="store_true",
+            help="Output results in formatted JSON",
+        )
+        parser.add_argument(
+            "--data",
+            type=str,
+            metavar="FILENAME",
+            action="store",
+            dest="json",
+            help="A JSON file containing data to run the rule against",
+        )
+        parser.add_argument(
+            "--alert",
+            action="store_true",
+            help="Use actual alerts instead of debug output",
+        )
+        parser.add_argument(
+            "--save-json",
+            type=str,
+            metavar="FILENAME",
+            action="store",
+            dest="save",
+            help="A file to which documents from the last day or --days will be saved",
+        )
+        parser.add_argument(
+            "--use-downloaded",
+            action="store_true",
+            dest="use_downloaded",
+            help="Use the downloaded",
+        )
+        parser.add_argument(
+            "--max-query-size",
+            type=int,
+            default=10000,
+            action="store",
+            dest="max_query_size",
+            help="Maximum size of any query",
+        )
+        parser.add_argument(
+            "--count-only",
+            action="store_true",
+            dest="count",
+            help="Only display the number of documents matching the filter",
+        )
+        parser.add_argument(
+            "--config",
+            action="store",
+            dest="config",
+            help="Global config file.",
+        )
+        parsed_args = parser.parse_args(args)
+
+        # Set arguments that ElastAlerter needs
+        parsed_args.verbose = parsed_args.alert
+        parsed_args.debug = not parsed_args.alert
+        parsed_args.es_debug = False
+        parsed_args.es_debug_trace = False
+
+        return parsed_args
+
+    def __init__(self, args):
+        self.args = self._parse_args(args)
         self.data = []
         self.formatted_output = {}
         self.ts_now = ts_now()
+        self.starttime = (
+            ts_to_dt(self.args.start)
+            if self.args.start
+            else (
+                self.ts_now
+                - datetime.timedelta(days=self.args.days if self.args.days != 0 else 1)
+            )
+        )
+        self.endtime = ts_to_dt(self.args.end) if self.args.end else self.ts_now
 
-    def test_file(self, conf, args):
-        """ Loads a rule config file, performs a query over the last day (args.days), lists available keys
-        and prints the number of results. """
-        if args.schema_only:
+    def test_file(self, conf):
+        """Loads a rule config file, performs a query over the last day (self.args.days), lists available keys
+        and prints the number of results."""
+        if self.args.schema_only:
             return []
 
         # Set up Elasticsearch client and query
@@ -60,34 +166,25 @@ class MockElastAlerter(object):
             ElastAlerter.modify_rule_for_ES5(conf)
         except EAException as ea:
             print('Invalid filter provided:', str(ea), file=sys.stderr)
-            if args.stop_error:
+            if self.args.stop_error:
                 exit(3)
             return None
         except Exception as e:
             print("Error connecting to ElasticSearch:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)
-            if args.stop_error:
+            if self.args.stop_error:
                 exit(1)
             return None
-        start_time = (
-            ts_to_dt(args.start)
-            if args.start
-            else (
-                self.ts_now
-                - datetime.timedelta(days=args.days if args.days != 0 else 1)
-            )
-        )
-        end_time = ts_to_dt(args.end) if args.end else self.ts_now
         ts = conf.get('timestamp_field', '@timestamp')
         query = ElastAlerter.get_query(
             conf['filter'],
-            starttime=start_time,
-            endtime=end_time,
+            starttime=self.starttime,
+            endtime=self.endtime,
             timestamp_field=ts,
             to_ts_func=conf['dt_to_ts'],
             five=conf['five']
         )
-        index = ElastAlerter.get_index(conf, start_time, end_time)
+        index = ElastAlerter.get_index(conf, self.starttime, self.endtime)
 
         # Get one document for schema
         try:
@@ -95,7 +192,7 @@ class MockElastAlerter(object):
         except Exception as e:
             print("Error running your filter:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)
-            if args.stop_error:
+            if self.args.stop_error:
                 exit(3)
             return None
         num_hits = len(res['hits']['hits'])
@@ -109,8 +206,8 @@ class MockElastAlerter(object):
         # Get a count of all docs
         count_query = ElastAlerter.get_query(
             conf['filter'],
-            starttime=start_time,
-            endtime=end_time,
+            starttime=self.starttime,
+            endtime=self.endtime,
             timestamp_field=ts,
             to_ts_func=conf['dt_to_ts'],
             sort=False,
@@ -121,19 +218,22 @@ class MockElastAlerter(object):
         except Exception as e:
             print("Error querying Elasticsearch:", file=sys.stderr)
             print(repr(e)[:2048], file=sys.stderr)
-            if args.stop_error:
+            if self.args.stop_error:
                 exit(2)
             return None
 
         num_hits = res['count']
 
-        if args.formatted_output:
+        if self.args.formatted_output:
             self.formatted_output['hits'] = num_hits
-            self.formatted_output['days'] = args.days
+            self.formatted_output['days'] = self.args.days
             self.formatted_output['terms'] = list(terms.keys())
             self.formatted_output['result'] = terms
         else:
-            print("Got %s hits from the last %s day%s" % (num_hits, args.days, 's' if args.days > 1 else ''))
+            print(
+                "Got %s hits from the last %s day%s"
+                % (num_hits, self.args.days, "s" if self.args.days > 1 else "")
+            )
             print("\nAvailable terms in first hit:")
             print_terms(terms, '')
 
@@ -155,22 +255,22 @@ class MockElastAlerter(object):
             # If the index starts with 'logstash', fields with .raw will be available but won't in _source
             if term not in terms and not (term.endswith('.raw') and term[:-4] in terms and index.startswith('logstash')):
                 print("top_count_key %s may be missing" % (term), file=sys.stderr)
-        if not args.formatted_output:
+        if not self.args.formatted_output:
             print('')  # Newline
 
         # Download up to max_query_size (defaults to 10,000) documents to save
-        if (args.save or args.formatted_output) and not args.count:
+        if (self.args.save or self.args.formatted_output) and not self.args.count:
             try:
-                res = es_client.search(index=index, size=args.max_query_size, body=query, ignore_unavailable=True)
+                res = es_client.search(index=index, size=self.args.max_query_size, body=query, ignore_unavailable=True)
             except Exception as e:
                 print("Error running your filter:", file=sys.stderr)
                 print(repr(e)[:2048], file=sys.stderr)
-                if args.stop_error:
+                if self.args.stop_error:
                     exit(2)
                 return None
             num_hits = len(res['hits']['hits'])
 
-            if args.save:
+            if self.args.save:
                 print("Downloaded %s documents to save" % (num_hits))
             return res['hits']['hits']
 
@@ -230,19 +330,19 @@ class MockElastAlerter(object):
         elastalert.get_hits = self.mock_hits
         elastalert.elasticsearch_client = mock.Mock()
 
-    def run_elastalert(self, rule, conf, args):
+    def run_elastalert(self, rule, conf):
         """ Creates an ElastAlert instance and run's over for a specific rule using either real or mock data. """
 
         # Load and instantiate rule
         # Pass an args containing the context of whether we're alerting or not
         # It is needed to prevent unnecessary initialization of unused alerters
         load_modules_args = argparse.Namespace()
-        load_modules_args.debug = not args.alert
+        load_modules_args.debug = not self.args.alert
         conf['rules_loader'].load_modules(rule, load_modules_args)
 
         # If using mock data, make sure it's sorted and find appropriate time range
         timestamp_field = rule.get('timestamp_field', '@timestamp')
-        if args.json:
+        if self.args.json:
             if not self.data:
                 return None
             try:
@@ -252,7 +352,7 @@ class MockElastAlerter(object):
                 endtime = ts_to_dt(endtime) + datetime.timedelta(seconds=1)
             except KeyError as e:
                 print("All documents must have a timestamp and _id: %s" % (e), file=sys.stderr)
-                if args.stop_error:
+                if self.args.stop_error:
                     exit(4)
                 return None
 
@@ -269,27 +369,27 @@ class MockElastAlerter(object):
             for doc in self.data:
                 doc.update({'_id': doc.get('_id', get_id())})
         else:
-            if args.end:
-                if args.end == 'NOW':
+            if self.args.end:
+                if self.args.end == 'NOW':
                     endtime = self.ts_now
                 else:
                     try:
-                        endtime = ts_to_dt(args.end)
+                        endtime = ts_to_dt(self.args.end)
                     except (TypeError, ValueError):
-                        self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (args.end))
+                        self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (self.args.end))
                         exit(4)
             else:
                 endtime = self.ts_now
-            if args.start:
+            if self.args.start:
                 try:
-                    starttime = ts_to_dt(args.start)
+                    starttime = ts_to_dt(self.args.start)
                 except (TypeError, ValueError):
-                    self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (args.start))
+                    self.handle_error("%s is not a valid ISO8601 timestamp (YYYY-MM-DDTHH:MM:SS+XX:00)" % (self.args.start))
                     exit(4)
             else:
                 # if days given as command line argument
-                if args.days > 0:
-                    starttime = endtime - datetime.timedelta(days=args.days)
+                if self.args.days > 0:
+                    starttime = endtime - datetime.timedelta(days=self.args.days)
                 else:
                     # if timeframe is given in rule
                     if 'timeframe' in rule:
@@ -309,13 +409,13 @@ class MockElastAlerter(object):
                 load_rules.return_value = [rule]
                 with mock.patch('elastalert.elastalert.load_conf') as load_conf:
                     load_conf.return_value = conf
-                    if args.alert:
+                    if self.args.alert:
                         client = ElastAlerter(['--verbose'])
                     else:
                         client = ElastAlerter(['--debug'])
 
         # Replace get_hits_* functions to use mock data
-        if args.json:
+        if self.args.json:
             self.mock_elastalert(client)
 
         # Mock writeback to return empty results
@@ -327,72 +427,24 @@ class MockElastAlerter(object):
 
             if mock_writeback.call_count:
 
-                if args.formatted_output:
+                if self.args.formatted_output:
                     self.formatted_output['writeback'] = {}
                 else:
                     print("\nWould have written the following documents to writeback index (default is elastalert_status):\n")
 
                 errors = False
                 for call in mock_writeback.call_args_list:
-                    if args.formatted_output:
+                    if self.args.formatted_output:
                         self.formatted_output['writeback'][call[0][0]] = json.loads(json.dumps(call[0][1], default=str))
                     else:
                         print("%s - %s\n" % (call[0][0], call[0][1]))
 
                     if call[0][0] == 'elastalert_error':
                         errors = True
-                if errors and args.stop_error:
+                if errors and self.args.stop_error:
                     exit(2)
 
     def run_rule_test(self):
-        """
-        Uses args to run the various components of MockElastAlerter such as loading the file, saving data, loading data, and running.
-        """
-        parser = argparse.ArgumentParser(description='Validate a rule configuration')
-        parser.add_argument('file', metavar='rule', type=str, help='rule configuration filename')
-        parser.add_argument('--schema-only', action='store_true', help='Show only schema errors; do not run query')
-        parser.add_argument('--days', type=int, default=0, action='store', help='Query the previous N days with this rule')
-        parser.add_argument('--start', dest='start', help='YYYY-MM-DDTHH:MM:SS Start querying from this timestamp.')
-        parser.add_argument('--end', dest='end', help='YYYY-MM-DDTHH:MM:SS Query to this timestamp. (Default: present) '
-                                                      'Use "NOW" to start from current time. (Default: present)')
-        parser.add_argument('--stop-error', action='store_true', help='Stop the entire test right after the first error')
-        parser.add_argument('--formatted-output', action='store_true', help='Output results in formatted JSON')
-        parser.add_argument(
-            '--data',
-            type=str,
-            metavar='FILENAME',
-            action='store',
-            dest='json',
-            help='A JSON file containing data to run the rule against')
-        parser.add_argument('--alert', action='store_true', help='Use actual alerts instead of debug output')
-        parser.add_argument(
-            '--save-json',
-            type=str,
-            metavar='FILENAME',
-            action='store',
-            dest='save',
-            help='A file to which documents from the last day or --days will be saved')
-        parser.add_argument(
-            '--use-downloaded',
-            action='store_true',
-            dest='use_downloaded',
-            help='Use the downloaded '
-        )
-        parser.add_argument(
-            '--max-query-size',
-            type=int,
-            default=10000,
-            action='store',
-            dest='max_query_size',
-            help='Maximum size of any query')
-        parser.add_argument(
-            '--count-only',
-            action='store_true',
-            dest='count',
-            help='Only display the number of documents matching the filter')
-        parser.add_argument('--config', action='store', dest='config', help='Global config file.')
-        args = parser.parse_args()
-
         defaults = {
             'rules_folder': 'rules',
             'es_host': 'localhost',
@@ -410,19 +462,16 @@ class MockElastAlerter(object):
             'rules_loader': 'file',
         }
 
-        # Set arguments that ElastAlerter needs
-        args.verbose = args.alert
-        args.debug = not args.alert
-        args.es_debug = False
-        args.es_debug_trace = False
+        conf = load_conf(self.args, defaults, overwrites)
+        rule_yaml = conf['rules_loader'].load_yaml(self.args.file)
+        conf['rules_loader'].load_options(rule_yaml, conf, self.args.file)
 
-        conf = load_conf(args, defaults, overwrites)
-        rule_yaml = conf['rules_loader'].load_yaml(args.file)
-        conf['rules_loader'].load_options(rule_yaml, conf, args.file)
-
-        if args.json:
-            with open(args.json, 'r') as data_file:
-                self.data = json.loads(data_file.read())
+        if self.args.json:
+            try:
+                with open(self.args.json, "r") as data_file:
+                    self.data = json.loads(data_file.read())
+            except OSError:
+                raise
         else:
             # Temporarily remove the jinja_template, if it exists, to avoid deepcopy issues
             template = rule_yaml.get("jinja_template")
@@ -435,33 +484,41 @@ class MockElastAlerter(object):
             rule_yaml["jinja_template"] = template
             copied_rule["jinja_template"] = template
 
-            hits = self.test_file(copied_rule, args)
-            if hits and args.formatted_output:
+            hits = self.test_file(copied_rule)
+            if hits and self.args.formatted_output:
                 self.formatted_output['results'] = json.loads(json.dumps(hits))
-            if hits and args.save:
-                with open(args.save, 'wb') as data_file:
-                    # Add _id to _source for dump
-                    [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
-                    data_file.write(str.encode(json.dumps([doc['_source'] for doc in hits], indent=4)))
-            if args.use_downloaded:
+            if hits and self.args.save:
+                try:
+                    with open(self.args.save, "wb") as data_file:
+                        # Add _id to _source for dump
+                        [doc['_source'].update({'_id': doc['_id']}) for doc in hits]
+                        data_file.write(str.encode(json.dumps([doc['_source'] for doc in hits], indent=4)))
+                except OSError:
+                    raise
+            if self.args.use_downloaded:
                 if hits:
-                    args.json = args.save
-                    with open(args.json, 'r') as data_file:
-                        self.data = json.loads(data_file.read())
+                    self.args.json = self.args.save
+                    try:
+                        with open(self.args.json, "r") as data_file:
+                            self.data = json.loads(data_file.read())
+                    except OSError:
+                        raise
                 else:
                     self.data = []
 
-        if not args.schema_only and not args.count:
-            self.run_elastalert(rule_yaml, conf, args)
+        if not self.args.schema_only and not self.args.count:
+            self.run_elastalert(rule_yaml, conf)
 
-        if args.formatted_output:
+        if self.args.formatted_output:
             print(json.dumps(self.formatted_output))
 
 
-def main():
-    test_instance = MockElastAlerter()
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    test_instance = MockElastAlerter(args)
     test_instance.run_rule_test()
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Signed-off-by: Thibaud CANALE <thican@thican.net>

## Description

The saving feature was unable to save content without the none default --days argument.
Now it should be able to store content with --start/--end and for the last day without --days argument, as described in the help section of arguments.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [Y] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [N] I have included unit tests for my changes or additions.
- [N] I have successfully run `make test-docker` with my changes.
- [N] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [Y] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I was unable to test my commit because I met some issue to run the Docker test (I am behind a corporate proxy, I fails to fetch content from the WAN) or to execute directly the Python script (some circular imports issues).
About the documentation, this is a fix so there is nothing to update.

If someone could test for me, my tries were unsuccessful:
```
python3.9 elastalert/test_rule.py --config content/config/my_config.yaml --save-json content/data/my_data.json content/rules/my_rule.yaml
```

As you might have noticed, I store the timestamp in the class instead of querying for each call, this allows to keep a steady differential between days.

Best regards,