### PR TITLE
Add custom description for OpsGenie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - None
 
 ## New features
-- [OpsGenie] Add support for custom description - [#455](https://github.com/jertel/elastalert2/pull/455) - @nickbabkin
+- [OpsGenie] Add support for custom description - [#457](https://github.com/jertel/elastalert2/pull/457) - @nickbabkin
 - Added support for markdown style formatting of aggregation tables - [#415](https://github.com/jertel/elastalert2/pull/415) - @Neuro-HSOC
 
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - None
 
 ## New features
+- [OpsGenie] Add support for custom description - [#455](https://github.com/jertel/elastalert2/pull/455) - @nickbabkin
 - Added support for markdown style formatting of aggregation tables - [#415](https://github.com/jertel/elastalert2/pull/415) - @Neuro-HSOC
 
 ## Other changes

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2364,6 +2364,8 @@ Optional:
 
 ``opsgenie_message``: Set the OpsGenie message to something other than the rule name. The message can be formatted with fields from the first match e.g. "Error occurred for {app_name} at {timestamp}.".
 
+``opsgenie_description``: Set the OpsGenie description to something other than the rule body. The message can be formatted with fields from the first match e.g. "Error occurred for {app_name} at {timestamp}.".
+
 ``opsgenie_alias``: Set the OpsGenie alias. The alias can be formatted with fields from the first match e.g "{app_name} error".
 
 ``opsgenie_subject``: A string used to create the title of the OpsGenie alert. Can use Python string formatting.

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -23,6 +23,7 @@ class OpsGenieAlerter(Alerter):
         self.teams_args = self.rule.get('opsgenie_teams_args')
         self.tags = self.rule.get('opsgenie_tags', []) + ['ElastAlert', self.rule['name']]
         self.to_addr = self.rule.get('opsgenie_addr', 'https://api.opsgenie.com/v2/alerts')
+        self.description = self.rule.get('opsgenie_description', None)
         self.custom_message = self.rule.get('opsgenie_message')
         self.opsgenie_subject = self.rule.get('opsgenie_subject')
         self.opsgenie_subject_args = self.rule.get('opsgenie_subject_args')
@@ -77,7 +78,10 @@ class OpsGenieAlerter(Alerter):
             post['responders'] = [{'username': r, 'type': 'user'} for r in self.recipients]
         if self.teams:
             post['teams'] = [{'name': r, 'type': 'team'} for r in self.teams]
-        post['description'] = body
+        if self.description:
+            post['description'] = self.description.format(**matches[0])
+        else:
+            post['description'] = body
         if self.entity:
             post['entity'] = self.entity.format(**matches[0])
         if self.source:

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1083,7 +1083,7 @@ def test_opsgenie_create_custom_description():
         'type': mock_rule(),
         'opsgenie_account': 'genies',
         'opsgenie_key': 'ogkey',
-        'opsgenie_description': "Custom description"
+        'opsgenie_description': "Custom Description"
         'opsgenie_details': {
             'Message': {'field': 'message'},
             'Missing': {'field': 'missing'}

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1077,17 +1077,19 @@ def test_opsgenie_create_custom_title():
     excepted = 'abc Testing 2014-10-31T00:00:00'
     assert excepted == actual
 
+
 def test_opsgenie_create_custom_description():
     rule = {
         'name': 'Opsgenie Details',
         'type': mock_rule(),
         'opsgenie_account': 'genies',
         'opsgenie_key': 'ogkey',
-        'opsgenie_description': "Custom Description"
+        'opsgenie_description': 'Custom Description',
         'opsgenie_details': {
             'Message': {'field': 'message'},
             'Missing': {'field': 'missing'}
-        }
+        },
+        'opsgenie_subject': 'test1'
     }
     match = {
         'message': 'Testing',
@@ -1111,9 +1113,10 @@ def test_opsgenie_create_custom_description():
     expected_json = {
         'description': 'Custom Description',
         'details': {'Message': 'Testing'},
-        'message': 'ElastAlert: Opsgenie Details',
+        'message': 'test1',
         'priority': None,
         'source': 'ElastAlert',
+        'tags': ['ElastAlert', 'Opsgenie Details'],
         'user': 'genies'
     }
     actual_json = mock_post_request.call_args_list[0][1]['json']

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1077,6 +1077,48 @@ def test_opsgenie_create_custom_title():
     excepted = 'abc Testing 2014-10-31T00:00:00'
     assert excepted == actual
 
+def test_opsgenie_create_custom_description():
+    rule = {
+        'name': 'Opsgenie Details',
+        'type': mock_rule(),
+        'opsgenie_account': 'genies',
+        'opsgenie_key': 'ogkey',
+        'opsgenie_description': "Custom description"
+        'opsgenie_details': {
+            'Message': {'field': 'message'},
+            'Missing': {'field': 'missing'}
+        }
+    }
+    match = {
+        'message': 'Testing',
+        '@timestamp': '2014-10-31T00:00:00'
+    }
+    alert = OpsGenieAlerter(rule)
+
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    mock_post_request.assert_called_once_with(
+        'https://api.opsgenie.com/v2/alerts',
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': 'GenieKey ogkey'
+        },
+        json=mock.ANY,
+        proxies=None
+    )
+
+    expected_json = {
+        'description': 'Custom Description',
+        'details': {'Message': 'Testing'},
+        'message': 'ElastAlert: Opsgenie Details',
+        'priority': None,
+        'source': 'ElastAlert',
+        'user': 'genies'
+    }
+    actual_json = mock_post_request.call_args_list[0][1]['json']
+    assert expected_json == actual_json
+
 
 def test_opsgenie_get_details():
     rule = {


### PR DESCRIPTION
## Description

This change allows to set custom description field for OpsGenie alerts for more flexibility. Example use cases: where sensitive alert data must be masked from body before passing it to OpsGenie. 

Description can be dynamically formatted from match by using {field} tags.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
