### PR TITLE
Add missing show_ssl_warn and silence_qk_value params to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Fixed typo in default setting accidentally introduced in [#407](https://github.com/jertel/elastalert2/pull/407)  - [#413](https://github.com/jertel/elastalert2/pull/413) - @perceptron01
 - Fix saving feature which was ignoring --start/--end, and storing no content with default --days value to 0
 - Changed the wording of ElastAlert to ElastAlert 2 and Update FAQ -[#446](https://github.com/jertel/elastalert2/pull/446) - @nsano-rururu
+- Add missing show_ssl_warn and silence_qk_value params to docs - [#469](https://github.com/jertel/elastalert2/pull/469) - @jertel
+
 # 2.2.1
 
 ## Breaking changes

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -268,6 +268,11 @@ use_ssl
 ``use_ssl``: Whether or not to connect to ``es_host`` using TLS. (Optional, boolean, default False)
 The environment variable ``ES_USE_SSL`` will override this field.
 
+ssl_show_warn
+^^^^^^^
+
+``ssl_show_warn``: Whether or not to show SSL/TLS warnings when ``verify_certs`` is disabled. (Optional, boolean, default True)
+
 verify_certs
 ^^^^^^^^^^^^
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -269,7 +269,7 @@ use_ssl
 The environment variable ``ES_USE_SSL`` will override this field.
 
 ssl_show_warn
-^^^^^^^
+^^^^^^^^^^^^^
 
 ``ssl_show_warn``: Whether or not to show SSL/TLS warnings when ``verify_certs`` is disabled. (Optional, boolean, default True)
 

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -56,6 +56,10 @@ days, weeks, hours, minutes or seconds. <number> is an integer. For example,
 ``--rule noisy_rule.yaml --silence hours=4`` will stop noisy_rule from
 generating any alerts for 4 hours.
 
+``--silence_qk_value <value`` will silence the rule only for the given 
+query key value. This parameter is intended to be used with the ``--rule`` 
+parameter.
+
 ``--start <timestamp>`` will force ElastAlert 2 to begin querying from the given
 time, instead of the default, querying from the present. The timestamp should be
 ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone


### PR DESCRIPTION
## Description

Provide missing documentation as mentioned in #467 and #468.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
