### PR TITLE
Support OpenSearch v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [OpsGenie] Add support for custom description - [#457](https://github.com/jertel/elastalert2/pull/457), [#460](https://github.com/jertel/elastalert2/pull/460) - @nickbabkin
 - [Tencent SMS] Added support for Tencent SMS - [#470](https://github.com/jertel/elastalert2/pull/470) - @liuxingjun
 - Add support for Kibana 7.15 for Kibana Discover - [#481](https://github.com/jertel/elastalert2/pull/481) - @nsano-rururu
-- Add support for OpenSearch v1.0.0 [#483](https://github.com/jertel/elastalert2/pull/483) @nbrownus
+- Begin working toward support of OpenSearch (This is still a work in progress) [#483](https://github.com/jertel/elastalert2/pull/483) @nbrownus
 
 ## Other changes
 - [Rule Test] Fix issue related to --start/--end/--days params - [#424](https://github.com/jertel/elastalert2/pull/424), [#433](https://github.com/jertel/elastalert2/pull/433) - @thican

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [OpsGenie] Add support for custom description - [#457](https://github.com/jertel/elastalert2/pull/457), [#460](https://github.com/jertel/elastalert2/pull/460) - @nickbabkin
 - [Tencent SMS] Added support for Tencent SMS - [#470](https://github.com/jertel/elastalert2/pull/470) - @liuxingjun
 - Add support for Kibana 7.15 for Kibana Discover - [#481](https://github.com/jertel/elastalert2/pull/481) - @nsano-rururu
+- Add support for OpenSearch v1.0.0 [#483](https://github.com/jertel/elastalert2/pull/483) @nbrownus
 
 ## Other changes
 - [Rule Test] Fix issue related to --start/--end/--days params - [#424](https://github.com/jertel/elastalert2/pull/424), [#433](https://github.com/jertel/elastalert2/pull/433) - @thican

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -1,7 +1,7 @@
 ElastAlert 2 - Automated rule-based alerting for Elasticsearch
 **************************************************************
 
-ElastAlert 2 is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in `Elasticsearch <https://www.elastic.co/elasticsearch/>` and `OpenSearch <https://opensearch.org/>`.
+ElastAlert 2 is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in `Elasticsearch <https://www.elastic.co/elasticsearch/>` and `OpenSearch <https://opensearch.org/>` (Under development).
 
 If you have data being written into Elasticsearch in near real time and want to be alerted when that data matches certain patterns, ElastAlert 2 is the tool for you.
 

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -1,7 +1,7 @@
 ElastAlert 2 - Automated rule-based alerting for Elasticsearch
 **************************************************************
 
-ElastAlert 2 is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
+ElastAlert 2 is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in `Elasticsearch <https://www.elastic.co/elasticsearch/>` and `OpenSearch <https://opensearch.org/>`.
 
 If you have data being written into Elasticsearch in near real time and want to be alerted when that data matches certain patterns, ElastAlert 2 is the tool for you.
 

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -48,12 +48,13 @@ class ElasticSearchClient(Elasticsearch):
         if self._es_version is None:
             for retry in range(3):
                 try:
-                    if self.info()['version']['distribution'] == "opensearch":
+                    esinfo = self.info()['version']
+                    if esinfo['distribution'] == "opensearch":
                         # OpenSearch is based on Elasticsearch 7.10.2, currently only v1.0.0 exists
                         # https://opensearch.org/
                         self._es_version = "7.10.2"
                     else:
-                        self._es_version = self.info()['version']['number']
+                        self._es_version = esinfo['number']
                     break
                 except TransportError:
                     if retry == 2:

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -48,7 +48,12 @@ class ElasticSearchClient(Elasticsearch):
         if self._es_version is None:
             for retry in range(3):
                 try:
-                    self._es_version = self.info()['version']['number']
+                    if self.info()['version']['distribution'] == "opensearch":
+                        # OpenSearch is based on Elasticsearch 7.10.2, currently only v1.0.0 exists
+                        # https://opensearch.org/
+                        self._es_version = "7.10.2"
+                    else:
+                        self._es_version = self.info()['version']['number']
                     break
                 except TransportError:
                     if retry == 2:

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -20,8 +20,13 @@ env = Env(ES_USE_SSL=bool)
 
 
 def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None):
-    esversion = es_client.info()["version"]["number"]
-    print("Elastic Version: " + esversion)
+    esinfo = es_client.info()['version']
+    if esinfo['distribution'] == "opensearch":
+        # OpenSearch is based on Elasticsearch 7.10.2, currently only v1.0.0 exists
+        # https://opensearch.org/
+        esversion = "7.10.2"
+    else:
+        esversion = esinfo['version']
 
     es_index_mappings = read_es_index_mappings() if is_atleastsix(esversion) else read_es_index_mappings(5)
 

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -26,7 +26,7 @@ def create_index_mappings(es_client, ea_index, recreate=False, old_ea_index=None
         # https://opensearch.org/
         esversion = "7.10.2"
     else:
-        esversion = esinfo['version']
+        esversion = esinfo['number']
 
     es_index_mappings = read_es_index_mappings() if is_atleastsix(esversion) else read_es_index_mappings(5)
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -924,7 +924,7 @@ class NewTermsRule(RuleType):
             # https://opensearch.org/
             return True
         else:
-            return int(esinfo['version'][0]) >= 5
+            return int(esinfo['number'][0]) >= 5
 
 
 class CardinalityRule(RuleType):

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -918,8 +918,13 @@ class NewTermsRule(RuleType):
                         self.seen_values[field].append(bucket['key'])
 
     def is_five_or_above(self):
-        version = self.es.info()['version']['number']
-        return int(version[0]) >= 5
+        esinfo = self.es.info()['version']
+        if esinfo['distribution'] == "opensearch":
+            # OpenSearch is based on Elasticsearch 7.10.2, currently only v1.0.0 exists
+            # https://opensearch.org/
+            return True
+        else:
+            return int(esinfo['version'][0]) >= 5
 
 
 class CardinalityRule(RuleType):

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -567,7 +567,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         call_args = []
 
         # search is called with a mutable dict containing timestamps, this is required to test
@@ -619,7 +619,7 @@ def test_new_term():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 1
@@ -637,7 +637,7 @@ def test_new_term_nested_field():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -662,7 +662,7 @@ def test_new_term_with_terms():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         rule = NewTermsRule(rules)
 
         # Only 15 queries because of custom step size
@@ -732,7 +732,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         rule = NewTermsRule(rules)
 
         assert rule.es.search.call_count == 60
@@ -769,7 +769,7 @@ def test_new_term_with_composite_fields():
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
         mock_es.return_value = mock.Mock()
         mock_es.return_value.search.return_value = mock_res
-        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x'}}
+        mock_es.return_value.info.return_value = {'version': {'number': '2.x.x', 'distribution': 'mock-es'}}
         rule = NewTermsRule(rules)
     rule.add_data([{'@timestamp': ts_now(), 'a': 'key2'}])
     assert len(rule.matches) == 2


### PR DESCRIPTION
## Description

Maps OpenSearch (currently v1.0.0) to Elasticsearch v7.10.2 to enable appropriate compatibility

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I reviewed the tests and there aren't any covering existing version detection. Happy to add some but that would require some inventing that I assume the maintainers would have a strong opinion about.

~I have not modified any documentation, mainly because I am not sure how prominently you would want to voice that this project supports OpenSearch.~

Closes #482 