### PR TITLE
Adding documentation page on what ElastAlert metrics are being exposed via `--prometheus_port` configuration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - None
 
 ## Other changes
-- None
+- [Docs] Add exposed metrics documentation - [#498](https://github.com/jertel/elastalert2/pull/498) - @thisisxgp
 
 # 2.2.2
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    recipes/writing_filters
    recipes/adding_enhancements
    recipes/adding_loaders
+   recipes/exposing_rule_metrics
    recipes/signing_requests
    recipes/faq
 

--- a/docs/source/recipes/exposing_rule_metrics.rst
+++ b/docs/source/recipes/exposing_rule_metrics.rst
@@ -1,0 +1,58 @@
+.. _writingrules:
+
+Exposing Rule Metrics
+=====================
+
+Configuration
+-------------
+Running ElastAlert with ``--prometheus_port`` configuration flag will expose ElastAlert 2 Prometheus metrics on the specified port. Prometheus metrics are disabled by default.
+
+To expose ElastAlert rule metrics on port ``9979`` run the following command:
+
+.. code-block:: console
+
+    $ elastalert --config config.yaml --prometheus_port 9979 
+
+Rule Metrics
+------------
+
+The exposed metrics are in the `Prometheus text-based format <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>`_. Metrics are of the metric type `counter <https://prometheus.io/docs/concepts/metric_types/#counter>`_ or `gauge <https://prometheus.io/docs/concepts/metric_types/#gauge>`_ and follow the `Prometheus metric naming <https://prometheus.io/docs/practices/naming/>`_. 
+
+In the standard metric definition, the metric names are structured as follows:
+
+.. code-block:: console
+
+     elastalert_{metric}_{unit}
+
+Where:
+
+- ``{metric}`` is a unique name of the metric. For example, ``hits``.
+- ``{unit}`` is the unit of measurement of the metric value. For example, ``total`` is a counter type metric and ``created`` is a gauge type metric.
+
+All metrics except ``elastalert_errors_{unit}`` have values that apply to a particular rule name. In the exported metrics, these can be identified using the ``rule_name`` `Prometheus label <https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels>`_.
+
+Find below all available metrics:
+
++---------------------------------------+-----------------+---------------------------+---------------+
+|    METRIC                             |  Type           |  Description              |  Label        |
++=======================================+=================+===========================+===============+
+| ``elastalert_scrapes_{unit}``         | Counter, Gauge  | Number of scrapes         | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_hits_{unit}``            | Counter, Gauge  | Number of hit             | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_matches_{unit}``         | Counter, Gauge  | Number of matches         | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_time_taken_{unit}``      | Counter, Gauge  | Number of time taken      | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_alerts_sent_{unir}``     | Counter, Gauge  | Number of alerts sent     | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_alerts_not_sent_{unit}`` | Counter, Gauge  | Number of alerts not sent | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_alerts_silenced_{unit}`` | Counter, Gauge  | Number of silenced alerts | ``rule_name`` |
++---------------------------------------+-----------------+---------------------------+---------------+
+| ``elastalert_errors_{unit}``          | Counter, Gauge  | Number of errors          |               |
++---------------------------------------+-----------------+---------------------------+---------------+
+
+
+
+

--- a/docs/source/recipes/exposing_rule_metrics.rst
+++ b/docs/source/recipes/exposing_rule_metrics.rst
@@ -16,7 +16,7 @@ To expose ElastAlert rule metrics on port ``9979`` run the following command:
 Rule Metrics
 ------------
 
-The exposed metrics are in the `Prometheus text-based format <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>`_. Metrics are of the metric type `counter <https://prometheus.io/docs/concepts/metric_types/#counter>`_ or `gauge <https://prometheus.io/docs/concepts/metric_types/#gauge>`_ and follow the `Prometheus metric naming <https://prometheus.io/docs/practices/naming/>`_. 
+The metrics being exposed are related to the `ElastAlert metadata indices <https://elastalert2.readthedocs.io/en/latest/elastalert_status.html>`_. The exposed metrics are in the `Prometheus text-based format <https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format>`_. Metrics are of the metric type `counter <https://prometheus.io/docs/concepts/metric_types/#counter>`_ or `gauge <https://prometheus.io/docs/concepts/metric_types/#gauge>`_ and follow the `Prometheus metric naming <https://prometheus.io/docs/practices/naming/>`_. 
 
 In the standard metric definition, the metric names are structured as follows:
 
@@ -42,7 +42,7 @@ Find below all available metrics:
 +---------------------------------------+-----------------+---------------------------+---------------+
 | ``elastalert_matches_{unit}``         | Counter, Gauge  | Number of matches         | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
-| ``elastalert_time_taken_{unit}``      | Counter, Gauge  | Amount of time taken      | ``rule_name`` |
+| ``elastalert_time_taken_{unit}``      | Counter, Gauge  | Time taken in seconds     | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
 | ``elastalert_alerts_sent_{unir}``     | Counter, Gauge  | Number of alerts sent     | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+

--- a/docs/source/recipes/exposing_rule_metrics.rst
+++ b/docs/source/recipes/exposing_rule_metrics.rst
@@ -38,11 +38,11 @@ Find below all available metrics:
 +=======================================+=================+===========================+===============+
 | ``elastalert_scrapes_{unit}``         | Counter, Gauge  | Number of scrapes         | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
-| ``elastalert_hits_{unit}``            | Counter, Gauge  | Number of hit             | ``rule_name`` |
+| ``elastalert_hits_{unit}``            | Counter, Gauge  | Number of hits            | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
 | ``elastalert_matches_{unit}``         | Counter, Gauge  | Number of matches         | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
-| ``elastalert_time_taken_{unit}``      | Counter, Gauge  | Number of time taken      | ``rule_name`` |
+| ``elastalert_time_taken_{unit}``      | Counter, Gauge  | Amount of time taken      | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+
 | ``elastalert_alerts_sent_{unir}``     | Counter, Gauge  | Number of alerts sent     | ``rule_name`` |
 +---------------------------------------+-----------------+---------------------------+---------------+

--- a/docs/source/recipes/exposing_rule_metrics.rst
+++ b/docs/source/recipes/exposing_rule_metrics.rst
@@ -1,4 +1,4 @@
-.. _writingrules:
+.. _exposingrulemetrics:
 
 Exposing Rule Metrics
 =====================

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -44,7 +44,7 @@ logs `localhost:9200` instead of the actual ``es_host``:``es_port``.
 ``--pin_rules`` will stop ElastAlert 2 from loading, reloading or removing rules
 based on changes to their config files.
 
-``--prometheus_port`` exposes ElastAlert 2 Prometheus metrics on the specified
+``--prometheus_port`` exposes ElastAlert 2 `Prometheus metrics <https://elastalert2.readthedocs.io/en/latest/recipes/exposing_rule_metrics.html>`_ on the specified
 port. Prometheus metrics disabled by default.
 
 ``--rule <rule.yaml>`` will only run the given rule. The rule file may be a


### PR DESCRIPTION
## Description

This PR adds a new documentation page that explains what types of metrics can be exported when using the `--prometheus_port` configuration flag

## Checklist

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Comments

- This is a documentation change, it does not require a unit test
- I've tested it locally by running `make html && open build/html/recipes/exposing_rule_metrics.html`