### PR TITLE
Add 'summary_table_max_rows' configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## New features
 - [Alertmanager] Added support for Alertmanager - [#503](https://github.com/jertel/elastalert2/pull/503) - @nsano-rururu
+- Add summary_table_max_rows optional configuration to limit rows in summary tables - [#508](https://github.com/jertel/elastalert2/pull/508) - @mdavyt92
 
 ## Other changes
 - [Docs] Add exposed metrics documentation - [#498](https://github.com/jertel/elastalert2/pull/498) - @thisisxgp

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -394,6 +394,8 @@ For aggregations, there can sometimes be a large number of documents present in 
 
 The formatting style of the summary table can be switched between ``ascii`` (default) and ``markdown`` with parameter ``summary_table_type``. ``markdown`` might be the more suitable formatting for alerters supporting it like TheHive.
 
+The maximum number of rows in the summary table can be limited with the parameter ``summary_table_max_rows``.
+
 For example, if you wish to summarize the usernames and event_types that appear in the documents so that you can see the most relevant fields at a quick glance, you can set::
 
     summary_table_fields:
@@ -720,6 +722,11 @@ summary_table_type
 ^^^^^^^^^^^^^^^^^^^^
 
 ``summary_table_type``: Either ``ascii`` or ``markdown``. Select the table type to use for the aggregation summary. Defaults to ``ascii`` for the classical text based table.
+
+summary_table_max_rows
+^^^^^^^^^^^^^^^^^^^^^^
+
+``summary_table_max_rows``: Limit the maximum number of rows that will be shown in the summary table.
 
 summary_prefix
 ^^^^^^^^^^^^^^^^^^^^

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -241,6 +241,13 @@ properties:
   replace_dots_in_field_names: {type: boolean}
   scan_entire_timeframe: {type: boolean}
 
+  ### summary table
+  summary_table_fields: {type: array, items: {type: string}}
+  summary_table_type: {type: string, enum: ['ascii', 'markdown']}
+  summary_table_max_rows: {type: number}
+  summary_prefix: {type: string}
+  summary_suffix: {type: string}
+
   ### Kibana Discover App Link
   generate_kibana_discover_url: {type: boolean}
   kibana_discover_app_url: {type: string, format: uri}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -312,6 +312,32 @@ def test_alert_aggregation_summary_default_table():
     assert "| field_value | abc from match | 3     |" in summary_table
     assert "| field_value | cde from match | 2     |" in summary_table
 
+def test_alert_aggregation_summary_table_one_row():
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'A very long subject',
+        'aggregation': 1,
+        'summary_table_fields': ['field', 'abc'],
+        'summary_table_max_rows': 1,
+    }
+    matches = [
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+    ]
+    alert = Alerter(rule)
+    summary_table = str(alert.get_aggregation_summary_text(matches))
+    assert "+-------------+----------------+-------+" in summary_table
+    assert "|    field    |      abc       | count |" in summary_table
+    assert "+=============+================+=======+" in summary_table
+    assert "| field_value | abc from match | 3     |" in summary_table
+    assert "| field_value | cde from match | 2     |" not in summary_table
+    assert "Showing top 1 rows" in summary_table
 
 def test_alert_aggregation_summary_table_suffix_prefix():
     rule = {

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -312,6 +312,7 @@ def test_alert_aggregation_summary_default_table():
     assert "| field_value | abc from match | 3     |" in summary_table
     assert "| field_value | cde from match | 2     |" in summary_table
 
+
 def test_alert_aggregation_summary_table_one_row():
     rule = {
         'name': 'test_rule',
@@ -338,6 +339,7 @@ def test_alert_aggregation_summary_table_one_row():
     assert "| field_value | abc from match | 3     |" in summary_table
     assert "| field_value | cde from match | 2     |" not in summary_table
     assert "Showing top 1 rows" in summary_table
+
 
 def test_alert_aggregation_summary_table_suffix_prefix():
     rule = {


### PR DESCRIPTION
## Description

There is currently no way of limiting the number of rows in a summary_table. This can lead to very long "summary" tables that can break formatting when sending notifications.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

This is a small code change. I've been running this for a few days, there have been no issues.
