### PR TITLE
Reduce risk of sourceRef collision for The Hive alerts by using full UUID 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ## Other changes
 - [Rule Test] Fix issue related to --start/--end/--days params - [#424](https://github.com/jertel/elastalert2/pull/424), [#433](https://github.com/jertel/elastalert2/pull/433) - @thican
+- [TheHive] Reduce risk of sourceRef collision for Hive Alerts by using full UUID -[#513](https://github.com/jertel/elastalert2/pull/513) - @fwalloe
 - Changed the wording of ElastAlert to ElastAlert 2 and Update FAQ -[#446](https://github.com/jertel/elastalert2/pull/446) - @nsano-rururu
 - Add missing show_ssl_warn and silence_qk_value params to docs - [#469](https://github.com/jertel/elastalert2/pull/469) - @jertel
 - [OpsGenie] Clarify documentation for URL endpoint to use in European region - [#475](https://github.com/jertel/elastalert2/pull/475) - @nsano-rururu

--- a/elastalert/alerters/thehive.py
+++ b/elastalert/alerters/thehive.py
@@ -80,7 +80,7 @@ class HiveAlerter(Alerter):
             'customFields': {},
             'date': int(time.time()) * 1000,
             'description': self.create_alert_body(matches),
-            'sourceRef': str(uuid.uuid4())[0:6],
+            'sourceRef': str(uuid.uuid4()),
             'tags': [],
             'title': self.create_title(matches),
         }


### PR DESCRIPTION
## Description

Using the full UUID as sourceRef for The Hive alerts will reduce the risk of collisions. 

## Checklist

- [ X ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ N/A ] I have included unit tests for my changes or additions.
- [ X ] I have successfully run `make test-docker` with my changes.
- [ X ] I have manually tested all relevant modes of the change in this PR.
- [ X ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ X ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
