### PR TITLE
add a path exist check for rules_folder config var

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -552,6 +552,8 @@ class FileRulesLoader(RulesLoader):
         rule_files = []
         if 'scan_subdirectories' in conf and conf['scan_subdirectories']:
             for ruledir in rule_folders:
+                if not os.path.exists(ruledir):
+                    raise EAException('Specified rule_folder does not exist: %s ' % ruledir)
                 for root, folders, files in os.walk(ruledir, followlinks=True):
                     # Openshift/k8s configmap fix for ..data and ..2021_05..date directories that loop with os.walk()
                     folders[:] = [d for d in folders if not d.startswith('..')]

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -14,7 +14,7 @@ from elastalert.loaders import FileRulesLoader
 from elastalert.loaders import RulesLoader
 from elastalert.util import EAException
 
-test_config = {'rules_folder': 'test_folder',
+test_config = {'rules_folder': './empty_folder_test',
                'run_every': {'minutes': 10},
                'buffer_time': {'minutes': 10},
                'es_host': 'elasticsearch.test',
@@ -168,7 +168,7 @@ def test_load_inline_alert_rule():
 
 
 def test_file_rules_loader_get_names_recursive():
-    conf = {'scan_subdirectories': True, 'rules_folder': 'root'}
+    conf = {'scan_subdirectories': True, 'rules_folder': './empty_folder_test'}
     rules_loader = FileRulesLoader(conf)
     walk_paths = (('root', ['folder_a', 'folder_b'], ('rule.yaml',)),
                   ('root/folder_a', [], ('a.yaml', 'ab.yaml')),


### PR DESCRIPTION
## Description

<!--
var "rules_folder" is not checked before use, so if a bad path is given the rules list is empty and thus it can't be long to see why there is not alert. 
-->

## Checklist

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.