### PR TITLE
Fix OpsGenie tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ my_rules
 *.swp
 *~
 /rules/
+mod/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - max_scrolling_count now has a default value of 990 to avoid stack overflow crashes - [#509](https://github.com/jertel/elastalert2/pull/509) - @jertel
 - Update pytest 6.2.5, pytest-cov 3.0.0, pytest-xdist 2.4.0, pylint<2.12, tox 3.24.4 - [#511](https://github.com/jertel/elastalert2/pull/511) - @nsano-rururu
 - Added a check on the value of the path "rules_folder" to make sure it exists - [#519](https://github.com/jertel/elastalert2/pull/519) - @AntoineBlaud
+- [OpsGenie] Fix tags on subsequent alerts - [#537](https://github.com/jertel/elastalert2/pull/537) - @jertel
 
 # 2.2.2
 

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -87,9 +87,9 @@ class OpsGenieAlerter(Alerter):
         if self.source:
             post['source'] = self.source.format(**matches[0])
 
+        post['tags'] = []
         for i, tag in enumerate(self.tags):
-            self.tags[i] = tag.format(**matches[0])
-        post['tags'] = self.tags
+            post['tags'].append(tag.format(**matches[0]))
 
         priority = self.priority
         if priority:

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -401,23 +401,12 @@ def test_opsgenie_details_with_environment_variable_replacement(environ):
     assert expected_json == actual_json
 
 
-def test_opsgenie_tags():
-    rule = {
-        'name': 'Opsgenie Details',
-        'type': mock_rule(),
-        'opsgenie_account': 'genies',
-        'opsgenie_key': 'ogkey',
-        'opsgenie_details': {
-            'Message': {'field': 'message'},
-            'Missing': {'field': 'missing'}
-        },
-        'opsgenie_tags': ['test1', 'test2']
-    }
+def validateAlertTag(alert, rule, tagvalue):
     match = {
         'message': 'Testing',
+        'somefield': tagvalue,
         '@timestamp': '2014-10-31T00:00:00'
     }
-    alert = OpsGenieAlerter(rule)
 
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
@@ -438,11 +427,29 @@ def test_opsgenie_tags():
         'message': 'ElastAlert: Opsgenie Details',
         'priority': None,
         'source': 'ElastAlert',
-        'tags': ['test1', 'test2', 'ElastAlert', 'Opsgenie Details'],
+        'tags': [tagvalue, 'test2', 'ElastAlert', 'Opsgenie Details'],
         'user': 'genies'
     }
     actual_json = mock_post_request.call_args_list[0][1]['json']
     assert expected_json == actual_json
+
+
+def test_opsgenie_tags():
+    rule = {
+        'name': 'Opsgenie Details',
+        'type': mock_rule(),
+        'opsgenie_account': 'genies',
+        'opsgenie_key': 'ogkey',
+        'opsgenie_details': {
+            'Message': {'field': 'message'},
+            'Missing': {'field': 'missing'}
+        },
+        'opsgenie_tags': ['{somefield}', 'test2']
+    }
+
+    alert = OpsGenieAlerter(rule)
+    validateAlertTag(alert, rule, 'somevalue')
+    validateAlertTag(alert, rule, 'anothervalue')
 
 
 def test_opsgenie_message():


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

Fixes tags on subsequent OpsGenie alerts. Prior to this PR all tags would be static, initialized from the first alert.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [N/A] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
