### PR TITLE
Feature/add jira url to slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add summary_table_max_rows optional configuration to limit rows in summary tables - [#508](https://github.com/jertel/elastalert2/pull/508) - @mdavyt92
 - Added support for shortening Kibana Discover URLs using Kibana Shorten URL API - [#512](https://github.com/jertel/elastalert2/pull/512) - @JeffAshton
 - Added new alerter `HTTP Post 2` which allow more flexibility to build the body/headers of the request. - [#530](https://github.com/jertel/elastalert2/pull/530) - @lepouletsuisse
+- [Slack] Added new option to include url to jira created in the same pipeline. @hugefarsen
 
 ## Other changes
 - [Docs] Add exposed metrics documentation - [#498](https://github.com/jertel/elastalert2/pull/498) - @thisisxgp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Add summary_table_max_rows optional configuration to limit rows in summary tables - [#508](https://github.com/jertel/elastalert2/pull/508) - @mdavyt92
 - Added support for shortening Kibana Discover URLs using Kibana Shorten URL API - [#512](https://github.com/jertel/elastalert2/pull/512) - @JeffAshton
 - Added new alerter `HTTP Post 2` which allow more flexibility to build the body/headers of the request. - [#530](https://github.com/jertel/elastalert2/pull/530) - @lepouletsuisse
-- [Slack] Added new option to include url to jira ticket if it is created in the same pipeline. @hugefarsen
+- [Slack] Added new option to include url to jira ticket if it is created in the same pipeline. - [#547](https://github.com/jertel/elastalert2/pull/547) - @hugefarsen
 
 ## Other changes
 - [Docs] Add exposed metrics documentation - [#498](https://github.com/jertel/elastalert2/pull/498) - @thisisxgp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Add summary_table_max_rows optional configuration to limit rows in summary tables - [#508](https://github.com/jertel/elastalert2/pull/508) - @mdavyt92
 - Added support for shortening Kibana Discover URLs using Kibana Shorten URL API - [#512](https://github.com/jertel/elastalert2/pull/512) - @JeffAshton
 - Added new alerter `HTTP Post 2` which allow more flexibility to build the body/headers of the request. - [#530](https://github.com/jertel/elastalert2/pull/530) - @lepouletsuisse
-- [Slack] Added new option to include url to jira created in the same pipeline. @hugefarsen
+- [Slack] Added new option to include url to jira ticket if it is created in the same pipeline. @hugefarsen
 
 ## Other changes
 - [Docs] Add exposed metrics documentation - [#498](https://github.com/jertel/elastalert2/pull/498) - @thisisxgp

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2009,7 +2009,7 @@ Required:
 
 Optional:
 
-``discord_emoji_title``: By default ElastAlert 2 will use the ``:warning:`` emoji when posting to the channel. You can use a different emoji per ElastAlert 2 rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If slack_icon_url_override parameter is provided, emoji is ignored.
+``discord_emoji_title``: By default ElastAlert 2 will use the ``:warning:`` emoji when posting to the channel. You can use a different emoji per ElastAlert 2 rule. Any Apple emoji can be used, see http://emojipedia.org/apple/ . If discord_embed_icon_url parameter is provided, emoji is ignored.
 
 ``discord_proxy``: By default ElastAlert 2 will not use a network proxy to send notifications to Discord. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
@@ -2883,7 +2883,11 @@ Example slack_attach_kibana_discover_url, slack_kibana_discover_color, slack_kib
 
 ``slack_msg_pretext``: You can set the message attachment pretext using this option. Defaults to "".
 
-``slack_jira_url``: Add url to the jira ticket created. Only works if the Jira alert runs before Slack alert. Set the field to ``True`` in order to generate the url. Defaults to ``False``.
+``slack_attach_jira_ticket_url``: Add url to the jira ticket created. Only works if the Jira alert runs before Slack alert. Set the field to ``True`` in order to generate the url. Defaults to ``False``.
+
+``slack_jira_ticket_color``: The color of the Jira Ticket url attachment. Defaults to ``#ec4b98``.
+
+``slack_jira_ticket_title``: The title of the Jira Ticket url attachment. Defaults to ``Jira Ticket``.
 
 Splunk On-Call (Formerly VictorOps)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2883,7 +2883,7 @@ Example slack_attach_kibana_discover_url, slack_kibana_discover_color, slack_kib
 
 ``slack_msg_pretext``: You can set the message attachment pretext using this option. Defaults to "".
 
-``slack_jira_url``: Enables the attachment of the a Jira url to the slack notification. You need to have the Jira alert rule working and it needs to run before the Slack rule. Set the field to ``True`` in order to generate the url. Defaults to ``False``.
+``slack_jira_url``: Add url to the jira ticket created. Only works if the Jira alert runs before Slack alert. Set the field to ``True`` in order to generate the url. Defaults to ``False``.
 
 Splunk On-Call (Formerly VictorOps)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2883,6 +2883,8 @@ Example slack_attach_kibana_discover_url, slack_kibana_discover_color, slack_kib
 
 ``slack_msg_pretext``: You can set the message attachment pretext using this option. Defaults to "".
 
+``slack_jira_url``: Enables the attachment of the a Jira url to the slack notification. You need to have the Jira alert rule working and it needs to run before the Slack rule. Set the field to ``True`` in order to generate the url. Defaults to ``False``.
+
 Splunk On-Call (Formerly VictorOps)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/elastalert/alerters/slack.py
+++ b/elastalert/alerters/slack.py
@@ -96,11 +96,8 @@ class SlackAlerter(Alerter):
         if self.slack_alert_fields != '':
             payload['attachments'][0]['fields'] = self.populate_fields(matches)
 
-        if self.slack_jira_url:
-            if self.pipeline is not None and 'jira_ticket' in self.pipeline:
-                url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
-            else:
-                url = 'jira_ticket not included in pipeline'
+        if self.slack_jira_url and self.pipeline is not None and 'jira_ticket' in self.pipeline:
+            url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
 
             payload['attachments'][0]['fields'].append({
                 'title': 'Jira ticket',

--- a/elastalert/alerters/slack.py
+++ b/elastalert/alerters/slack.py
@@ -44,7 +44,9 @@ class SlackAlerter(Alerter):
         self.slack_author_link = self.rule.get('slack_author_link', '')
         self.slack_author_icon = self.rule.get('slack_author_icon', '')
         self.slack_msg_pretext = self.rule.get('slack_msg_pretext', '')
-        self.slack_jira_url = self.rule.get('slack_jira_url', False)
+        self.slack_attach_jira_ticket_url = self.rule.get('slack_attach_jira_ticket_url', False)
+        self.slack_jira_ticket_color = self.rule.get('slack_jira_ticket_color', '#ec4b98')
+        self.slack_jira_ticket_title = self.rule.get('slack_jira_ticket_title', 'Jira Ticket')
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -96,15 +98,6 @@ class SlackAlerter(Alerter):
         if self.slack_alert_fields != '':
             payload['attachments'][0]['fields'] = self.populate_fields(matches)
 
-        if self.slack_jira_url and self.pipeline is not None and 'jira_ticket' in self.pipeline:
-            url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
-
-            payload['attachments'][0]['fields'].append({
-                'title': 'Jira ticket',
-                'short': False,
-                'value': url
-            })
-
         if self.slack_icon_url_override != '':
             payload['icon_url'] = self.slack_icon_url_override
         else:
@@ -148,6 +141,15 @@ class SlackAlerter(Alerter):
                     'title': self.slack_kibana_discover_title,
                     'title_link': kibana_discover_url
                 })
+
+        if self.slack_attach_jira_ticket_url and self.pipeline is not None and 'jira_ticket' in self.pipeline:
+            jira_url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
+
+            payload['attachments'].append({
+                'color': self.slack_jira_ticket_color,
+                'title': self.slack_jira_ticket_title,
+                'title_link': jira_url
+            })
 
         for url in self.slack_webhook_url:
             for channel_override in self.slack_channel_override:

--- a/elastalert/alerters/slack.py
+++ b/elastalert/alerters/slack.py
@@ -44,6 +44,7 @@ class SlackAlerter(Alerter):
         self.slack_author_link = self.rule.get('slack_author_link', '')
         self.slack_author_icon = self.rule.get('slack_author_icon', '')
         self.slack_msg_pretext = self.rule.get('slack_msg_pretext', '')
+        self.slack_jira_url = self.rule.get('slack_jira_url', False)
 
     def format_body(self, body):
         # https://api.slack.com/docs/formatting
@@ -94,6 +95,18 @@ class SlackAlerter(Alerter):
         # if we have defined fields, populate noteable fields for the alert
         if self.slack_alert_fields != '':
             payload['attachments'][0]['fields'] = self.populate_fields(matches)
+
+        if self.slack_jira_url:
+            if self.pipeline is not None and 'jira_ticket' in self.pipeline:
+                url = '%s/browse/%s' % (self.pipeline['jira_server'], self.pipeline['jira_ticket'])
+            else:
+                url = 'jira_ticket not included in pipeline'
+
+            payload['attachments'][0]['fields'].append({
+                'title': 'Jira ticket',
+                'short': False,
+                'value': url
+            })
 
         if self.slack_icon_url_override != '':
             payload['icon_url'] = self.slack_icon_url_override

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -602,6 +602,9 @@ properties:
   slack_attach_kibana_discover_url: {type: boolean}
   slack_kibana_discover_color: {type: string}
   slack_kibana_discover_title: {type: string}
+  slack_attach_jira_ticket_url: {type: boolean}
+  slack_jira_ticket_color: {type: string}
+  slack_jira_ticket_title: {type: string}
   slack_ca_certs: {type: boolean}
   slack_footer: {type: string}
   slack_footer_icon: {type: string}

--- a/tests/alerters/slack_test.py
+++ b/tests/alerters/slack_test.py
@@ -1309,61 +1309,6 @@ def test_slack_msg_pretext():
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
-def test_slack_jira_url_not_present():
-    rule = {
-        'name': 'Test Rule',
-        'type': 'any',
-        'slack_webhook_url': 'http://please.dontgohere.slack',
-        'slack_username_override': 'elastalert',
-        'slack_msg_pretext': 'pretext value',
-        'alert_subject': 'Cool subject',
-        'alert': [],
-        'slack_jira_url': True
-    }
-    rules_loader = FileRulesLoader({})
-    rules_loader.load_modules(rule)
-    alert = SlackAlerter(rule)
-    match = {
-        '@timestamp': '2016-01-01T00:00:00',
-        'somefield': 'foobarbaz'
-    }
-    with mock.patch('requests.post') as mock_post_request:
-        alert.alert([match])
-
-    expected_data = {
-        'username': 'elastalert',
-        'channel': '',
-        'icon_emoji': ':ghost:',
-        'attachments': [
-            {
-                'color': 'danger',
-                'title': rule['alert_subject'],
-                'text': BasicMatchString(rule, match).__str__(),
-                'mrkdwn_in': ['text', 'pretext'],
-                'fields': [
-                    {
-                        'title': 'Jira ticket',
-                        'short': False,
-                        'value': 'jira_ticket not included in pipeline'
-                    }
-                ],
-                'pretext': 'pretext value'
-            }
-        ],
-        'text': '',
-        'parse': 'none'
-    }
-    mock_post_request.assert_called_once_with(
-        rule['slack_webhook_url'],
-        data=mock.ANY,
-        headers={'content-type': 'application/json'},
-        proxies=None,
-        verify=True,
-        timeout=10
-    )
-    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
-
-
 def test_slack_ea_exception():
     with pytest.raises(EAException) as ea:
         rule = {

--- a/tests/alerters/slack_test.py
+++ b/tests/alerters/slack_test.py
@@ -1309,6 +1309,7 @@ def test_slack_msg_pretext():
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
+
 def test_slack_ea_exception():
     with pytest.raises(EAException) as ea:
         rule = {
@@ -1397,3 +1398,56 @@ def test_slack_required_error(slack_webhook_url, expected_data):
         assert expected_data == actual_data
     except Exception as ea:
         assert expected_data in str(ea)
+
+
+def test_slack_attach_jira_url_when_generated():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_attach_jira_ticket_url': True,
+        'slack_jira_ticket_title': 'My Title',
+        'slack_jira_ticket_color': '#aabbcc',
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    alert.pipeline = {'jira_ticket': 'foo_ticket', 'jira_server': 'https://myjiraserver'}
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'parse': 'none',
+        'text': '',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': 'Test Rule',
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': []
+            },
+            {
+                'color': '#aabbcc',
+                'title': 'My Title',
+                'title_link': 'https://myjiraserver/browse/foo_ticket'
+            }
+        ],
+        'icon_emoji': ':ghost:',
+        'channel': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True,
+        timeout=10
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data

--- a/tests/alerters/slack_test.py
+++ b/tests/alerters/slack_test.py
@@ -1309,6 +1309,60 @@ def test_slack_msg_pretext():
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
+def test_slack_jira_url_not_present():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'slack_webhook_url': 'http://please.dontgohere.slack',
+        'slack_username_override': 'elastalert',
+        'slack_msg_pretext': 'pretext value',
+        'alert_subject': 'Cool subject',
+        'alert': [],
+        'slack_jira_url': True
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = SlackAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        'username': 'elastalert',
+        'channel': '',
+        'icon_emoji': ':ghost:',
+        'attachments': [
+            {
+                'color': 'danger',
+                'title': rule['alert_subject'],
+                'text': BasicMatchString(rule, match).__str__(),
+                'mrkdwn_in': ['text', 'pretext'],
+                'fields': [
+                    {
+                        'title': 'Jira ticket',
+                        'short': False,
+                        'value': 'jira_ticket not included in pipeline'
+                    }
+                ],
+                'pretext': 'pretext value'
+            }
+        ],
+        'text': '',
+        'parse': 'none'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['slack_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True,
+        timeout=10
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
 
 def test_slack_ea_exception():
     with pytest.raises(EAException) as ea:


### PR DESCRIPTION
## Description

Add possibility to attach an url to created Jira ticket, in the Slack alert.


## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I have not included tests because I am not sure on how to do integration tests in python. 
