### PR TITLE
Add metric_agg_script to MetricAggregationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - None
 
 ## New features
-- None
+- Add metric_agg_script to MetricAggregationRule [#558](https://github.com/jertel/elastalert2/pull/558) - @dequis
 
 ## Other changes
 - sphinx 4.2.0 to 4.3.0 and tzlocal==2.1 - [#561](https://github.com/jertel/elastalert2/pull/561) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1318,7 +1318,7 @@ default this is ``buffer_time``.
 This rule requires:
 
 ``metric_agg_key``: This is the name of the field over which the metric value will be calculated. The underlying type of this field must be
-supported by the specified aggregation type.
+supported by the specified aggregation type.  If using a scripted field via ``metric_agg_script``, this is the name for your scripted field
 
 ``metric_agg_type``: The type of metric aggregation to perform on the ``metric_agg_key`` field. This must be one of 'min', 'max', 'avg',
 'sum', 'cardinality', 'value_count'.
@@ -1335,6 +1335,12 @@ Optional:
 
 ``query_key``: Group metric calculations by this field. For each unique value of the ``query_key`` field, the metric will be calculated and
 evaluated separately against the threshold(s).
+
+``metric_agg_script``: A `Painless` formatted script describing how to calculate your metric on-the-fly::
+
+    metric_agg_key: myScriptedMetric
+    metric_agg_script:
+        script: doc['field1'].value * doc['field2'].value
 
 ``min_doc_count``: The minimum number of events in the current window needed for an alert to trigger.  Used in conjunction with ``query_key``,
 this will only consider terms which in their last ``buffer_time`` had at least ``min_doc_count`` records.  Default 1.

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1088,6 +1088,8 @@ class MetricAggregationRule(BaseAggregationRule):
         return message
 
     def generate_aggregation_query(self):
+        if self.rules.get('metric_agg_script'):
+            return {self.metric_key: {self.rules['metric_agg_type']: self.rules['metric_agg_script']}}
         query = {self.metric_key: {self.rules['metric_agg_type']: {'field': self.rules['metric_agg_key']}}}
         if self.rules['metric_agg_type'] in self.allowed_percent_aggregations:
             query[self.metric_key][self.rules['metric_agg_type']]['percents'] = [self.rules['percentile_range']]
@@ -1175,7 +1177,7 @@ class SpikeMetricAggregationRule(BaseAggregationRule, SpikeRule):
         self.rules['aggregation_query_element'] = self.generate_aggregation_query()
 
     def generate_aggregation_query(self):
-        """Lifted from MetricAggregationRule, added support for scripted fields"""
+        """Lifted from MetricAggregationRule"""
         if self.rules.get('metric_agg_script'):
             return {self.metric_key: {self.rules['metric_agg_type']: self.rules['metric_agg_script']}}
         query = {self.metric_key: {self.rules['metric_agg_type']: {'field': self.rules['metric_agg_key']}}}


### PR DESCRIPTION
## Description

Copied from SpikeMetricAggregationRule, which originally copied
generate_aggregation_query from MetricAggregationRule and added these
two lines.

So this commit just makes the two generate_aggregation_query look the
same, which just works and I'm not really sure why no one has done it
before.

Should not be a breaking change since it just adds an optional rule attribute.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

No idea how to unit test this. It runs against a mocked elasticsearch, right? I was planning to not write any until I saw this checklist so uh, that's a tomorrow problem.

Most of my manual testing was with an out of tree extension, but I haven't gotten around to test this specific version of the code, so that one is unchecked.

~~I can't really add a changelog entry before creating the pull request.~~

About the code: to be honest, this is a really lazy change, but it follows the trend of someone copypasting one version of `generate_aggregation_query`, modifying it a little and never applying that change to the original.

I don't know what's the best way to deduplicate these things, and doing something like `MetricAggregationRule.generate_aggregation_query(self)` would be needlessly obscure imo. Can't really deduplicate the docs.
