### PR TITLE
Fixing get_rule_file_hash to always return bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## Other changes
 - sphinx 4.2.0 to 4.3.0 and tzlocal==2.1 - [#561](https://github.com/jertel/elastalert2/pull/561) - @nsano-rururu
 - jinja2 3.0.1 to 3.0.3 - [#562](https://github.com/jertel/elastalert2/pull/562) - @nsano-rururu
+- Fix `get_rule_file_hash` TypeError - [#566](https://github.com/jertel/elastalert2/pull/566) - @JeffAshton
 
 # 2.2.3
 

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -606,12 +606,14 @@ class FileRulesLoader(RulesLoader):
         return expanded_imports
 
     def get_rule_file_hash(self, rule_file):
-        rule_file_hash = ''
         if os.path.exists(rule_file):
             with open(rule_file, 'rb') as fh:
                 rule_file_hash = hashlib.sha1(fh.read()).digest()
             for import_rule_file in self.import_rules.get(rule_file, []):
                 rule_file_hash += self.get_rule_file_hash(import_rule_file)
+        else:
+            not_found = 'ENOENT ' + rule_file
+            rule_file_hash = hashlib.sha1(not_found.encode('utf-8')).digest()
         return rule_file_hash
 
     @staticmethod

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from base64 import b64encode
 import copy
 import datetime
 import os
@@ -488,3 +489,12 @@ def test_get_import_rule():
     }
     result = RulesLoader.get_import_rule('', rule)
     assert 'a' == result
+
+
+def test_get_rule_file_hash_when_file_not_found():
+    test_config_copy = copy.deepcopy(test_config)
+    rules_loader = FileRulesLoader(test_config_copy)
+    hash = rules_loader.get_rule_file_hash('empty_folder_test/file_not_found.yml')
+    assert isinstance(hash, bytes)
+    b64Hash = b64encode(hash).decode('ascii')
+    assert 'zR1Ml8y8S8Z/I5j7b48OH+DJqUw=' == b64Hash


### PR DESCRIPTION
## Description

Fixing `get_rule_file_hash` for the case where an `import` is changed or removed, and the cached import path no longer exists.  `get_rule_file_hash` will now always return `bytes`.

```
"Job "Internal: Handle Config Change (trigger: interval[0:02:30], next run at: 2021-11-19 21:05:16 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/usr/local/lib/python3.10/site-packages/elastalert/elastalert.py", line 1312, in handle_config_change
    self.load_rule_changes()
  File "/usr/local/lib/python3.10/site-packages/elastalert/elastalert.py", line 1128, in load_rule_changes
    new_rule_hashes = self.rules_loader.get_hashes(self.conf, self.args.rule)
  File "/usr/local/lib/python3.10/site-packages/elastalert/loaders.py", line 577, in get_hashes
    rule_mod_times[rule_file] = self.get_rule_file_hash(rule_file)
  File "/usr/local/lib/python3.10/site-packages/elastalert/loaders.py", line 610, in get_rule_file_hash
    rule_file_hash += self.get_rule_file_hash(import_rule_file)
TypeError: can't concat str to bytes"
```

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Comments

`RulesLoader` should really be immutable.  The fact that it's stateful and caches `import_rules` is sketchy for updates.