### PR TITLE
Refactor loaders_test.py paths

### DIFF
--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -15,7 +15,9 @@ from elastalert.loaders import FileRulesLoader
 from elastalert.loaders import RulesLoader
 from elastalert.util import EAException
 
-test_config = {'rules_folder': './empty_folder_test',
+empty_folder_test_path = os.path.join(os.path.dirname(__file__), './empty_folder_test')
+
+test_config = {'rules_folder': empty_folder_test_path,
                'run_every': {'minutes': 10},
                'buffer_time': {'minutes': 10},
                'es_host': 'elasticsearch.test',
@@ -169,7 +171,7 @@ def test_load_inline_alert_rule():
 
 
 def test_file_rules_loader_get_names_recursive():
-    conf = {'scan_subdirectories': True, 'rules_folder': './empty_folder_test'}
+    conf = {'scan_subdirectories': True, 'rules_folder': empty_folder_test_path}
     rules_loader = FileRulesLoader(conf)
     walk_paths = (('root', ['folder_a', 'folder_b'], ('rule.yaml',)),
                   ('root/folder_a', [], ('a.yaml', 'ab.yaml')),

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -15,7 +15,7 @@ from elastalert.loaders import FileRulesLoader
 from elastalert.loaders import RulesLoader
 from elastalert.util import EAException
 
-empty_folder_test_path = os.path.join(os.path.dirname(__file__), './empty_folder_test')
+empty_folder_test_path = os.path.join(os.path.dirname(__file__), 'empty_folder_test')
 
 test_config = {'rules_folder': empty_folder_test_path,
                'run_every': {'minutes': 10},


### PR DESCRIPTION
## Description

Resolving empty_folder_test directory relative to loaders_test.py instead of working directory.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
