### PR TITLE
Tests to demonstrate bugs in FileRulesLoader

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -71,8 +71,6 @@ def load_rule_schema():
 
 
 class RulesLoader(object):
-    # import rule dependency
-    import_rules = {}
 
     # Required global (config.yaml) configuration options for the loader
     required_globals = frozenset([])
@@ -147,6 +145,7 @@ class RulesLoader(object):
     def __init__(self, conf):
         self.rule_schema = load_rule_schema()
         self.base_config = copy.deepcopy(conf)
+        self.import_rules = {} # import rule dependency
 
     def load(self, conf, args=None):
         """

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -508,7 +508,7 @@ def test_load_yaml_recursive_import():
     config = {}
     rules_loader = FileRulesLoader(config)
 
-    root_path = os.path.join(loaders_test_cases_path, 'recursive_import/root.yaml')
+    trunk_path = os.path.join(loaders_test_cases_path, 'recursive_import/trunk.yaml')
     branch_path = os.path.join(loaders_test_cases_path, 'recursive_import/branch.yaml')
     leaf_path = os.path.join(loaders_test_cases_path, 'recursive_import/leaf.yaml')
 
@@ -516,13 +516,14 @@ def test_load_yaml_recursive_import():
     assert leaf_yaml == {
         'name': 'leaf',
         'rule_file': leaf_path,
+        'diameter': '5cm',
     }
     assert sorted(rules_loader.import_rules.keys()) == [
         branch_path,
         leaf_path,
     ]
     assert rules_loader.import_rules[branch_path] == [
-        root_path,
+        trunk_path,
     ]
     assert rules_loader.import_rules[leaf_path] == [
         branch_path,
@@ -533,14 +534,15 @@ def test_load_yaml_recursive_import():
     assert leaf_yaml == {
         'name': 'leaf',
         'rule_file': leaf_path,
+        'diameter': '5cm',
     }
     assert sorted(rules_loader.import_rules.keys()) == [
         branch_path,
         leaf_path,
     ]
     assert rules_loader.import_rules[branch_path] == [
-        root_path,
-        root_path,  # memory leak
+        trunk_path,
+        trunk_path,  # memory leak
     ]
     assert rules_loader.import_rules[leaf_path] == [
         branch_path,
@@ -559,6 +561,7 @@ def test_load_yaml_multiple_imports():
     assert water_yaml == {
         'name': 'water',
         'rule_file': water_path,
+        'symbol': 'O',
     }
     assert sorted(rules_loader.import_rules.keys()) == [
         oxygen_path,
@@ -576,6 +579,7 @@ def test_load_yaml_multiple_imports():
     assert water_yaml == {
         'name': 'water',
         'rule_file': water_path,
+        'symbol': 'O',
     }
     assert sorted(rules_loader.import_rules.keys()) == [
         oxygen_path,

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -15,7 +15,9 @@ from elastalert.loaders import FileRulesLoader
 from elastalert.loaders import RulesLoader
 from elastalert.util import EAException
 
-empty_folder_test_path = os.path.join(os.path.dirname(__file__), 'empty_folder_test')
+
+loaders_test_cases_path = os.path.join(os.path.dirname(__file__), 'loaders_test_cases')
+empty_folder_test_path = os.path.join(loaders_test_cases_path, 'empty')
 
 test_config = {'rules_folder': empty_folder_test_path,
                'run_every': {'minutes': 10},
@@ -500,3 +502,47 @@ def test_get_rule_file_hash_when_file_not_found():
     assert isinstance(hash, bytes)
     b64Hash = b64encode(hash).decode('ascii')
     assert 'zR1Ml8y8S8Z/I5j7b48OH+DJqUw=' == b64Hash
+
+
+def test_load_yaml_recursive_import():
+    config = {}
+    rules_loader = FileRulesLoader(config)
+    print(rules_loader.import_rules)
+
+    root_path = os.path.join(loaders_test_cases_path, 'recursive_import/root.yaml')
+    branch_path = os.path.join(loaders_test_cases_path, 'recursive_import/branch.yaml')
+    leaf_path = os.path.join(loaders_test_cases_path, 'recursive_import/leaf.yaml')
+
+    leaf_yaml = rules_loader.load_yaml(leaf_path)
+    assert leaf_yaml == {
+        'name': 'leaf',
+        'rule_file': leaf_path,
+    }
+    assert sorted(rules_loader.import_rules.keys()) == [
+        branch_path,
+        leaf_path,
+    ]
+    assert rules_loader.import_rules[branch_path] == [
+        root_path,
+    ]
+    assert rules_loader.import_rules[leaf_path] == [
+        branch_path,
+    ]
+
+    # reload the rule
+    leaf_yaml = rules_loader.load_yaml(leaf_path)
+    assert leaf_yaml == {
+        'name': 'leaf',
+        'rule_file': leaf_path,
+    }
+    assert sorted(rules_loader.import_rules.keys()) == [
+        branch_path,
+        leaf_path,
+    ]
+    assert rules_loader.import_rules[branch_path] == [
+        root_path,
+        root_path,  # memory leak
+    ]
+    assert rules_loader.import_rules[leaf_path] == [
+        branch_path,
+    ]

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -507,7 +507,6 @@ def test_get_rule_file_hash_when_file_not_found():
 def test_load_yaml_recursive_import():
     config = {}
     rules_loader = FileRulesLoader(config)
-    print(rules_loader.import_rules)
 
     root_path = os.path.join(loaders_test_cases_path, 'recursive_import/root.yaml')
     branch_path = os.path.join(loaders_test_cases_path, 'recursive_import/branch.yaml')
@@ -545,4 +544,29 @@ def test_load_yaml_recursive_import():
     ]
     assert rules_loader.import_rules[leaf_path] == [
         branch_path,
+    ]
+
+
+def test_load_yaml_multiple_imports():
+    config = {}
+    rules_loader = FileRulesLoader(config)
+
+    hydrogen_path = os.path.join(loaders_test_cases_path, 'multiple_imports/hydrogen.yaml')
+    oxygen_path = os.path.join(loaders_test_cases_path, 'multiple_imports/oxygen.yaml')
+    water_path = os.path.join(loaders_test_cases_path, 'multiple_imports/water.yaml')
+
+    water_yaml = rules_loader.load_yaml(water_path)
+    assert water_yaml == {
+        'name': 'water',
+        'rule_file': water_path,
+    }
+    assert sorted(rules_loader.import_rules.keys()) == [
+        oxygen_path,
+        water_path,
+    ]
+    assert rules_loader.import_rules[oxygen_path] == [
+        hydrogen_path,
+    ]
+    assert rules_loader.import_rules[water_path] == [
+        oxygen_path,
     ]

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -587,7 +587,7 @@ def test_load_yaml_multiple_imports():
     ]
     assert rules_loader.import_rules[oxygen_path] == [
         hydrogen_path,
-        hydrogen_path,
+        hydrogen_path,  # memory leak
     ]
     assert rules_loader.import_rules[water_path] == [
         oxygen_path,

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -570,3 +570,21 @@ def test_load_yaml_multiple_imports():
     assert rules_loader.import_rules[water_path] == [
         oxygen_path,
     ]
+
+    # reload the rule
+    water_yaml = rules_loader.load_yaml(water_path)
+    assert water_yaml == {
+        'name': 'water',
+        'rule_file': water_path,
+    }
+    assert sorted(rules_loader.import_rules.keys()) == [
+        oxygen_path,
+        water_path,
+    ]
+    assert rules_loader.import_rules[oxygen_path] == [
+        hydrogen_path,
+        hydrogen_path,
+    ]
+    assert rules_loader.import_rules[water_path] == [
+        oxygen_path,
+    ]

--- a/tests/loaders_test_cases/multiple_imports/hydrogen.yaml
+++ b/tests/loaders_test_cases/multiple_imports/hydrogen.yaml
@@ -1,0 +1,1 @@
+name: hydrogen

--- a/tests/loaders_test_cases/multiple_imports/hydrogen.yaml
+++ b/tests/loaders_test_cases/multiple_imports/hydrogen.yaml
@@ -1,1 +1,2 @@
 name: hydrogen
+symbol: H

--- a/tests/loaders_test_cases/multiple_imports/oxygen.yaml
+++ b/tests/loaders_test_cases/multiple_imports/oxygen.yaml
@@ -1,1 +1,2 @@
 name: oxygen
+symbol: O

--- a/tests/loaders_test_cases/multiple_imports/oxygen.yaml
+++ b/tests/loaders_test_cases/multiple_imports/oxygen.yaml
@@ -1,0 +1,1 @@
+name: oxygen

--- a/tests/loaders_test_cases/multiple_imports/water.yaml
+++ b/tests/loaders_test_cases/multiple_imports/water.yaml
@@ -1,0 +1,4 @@
+name: water
+import:
+  - hydrogen.yaml
+  - oxygen.yaml

--- a/tests/loaders_test_cases/recursive_import/branch.yaml
+++ b/tests/loaders_test_cases/recursive_import/branch.yaml
@@ -1,0 +1,2 @@
+name: branch
+import: root.yaml

--- a/tests/loaders_test_cases/recursive_import/branch.yaml
+++ b/tests/loaders_test_cases/recursive_import/branch.yaml
@@ -1,2 +1,3 @@
 name: branch
-import: root.yaml
+import: trunk.yaml
+diameter: 5cm

--- a/tests/loaders_test_cases/recursive_import/leaf.yaml
+++ b/tests/loaders_test_cases/recursive_import/leaf.yaml
@@ -1,0 +1,2 @@
+name: leaf
+import: branch.yaml

--- a/tests/loaders_test_cases/recursive_import/root.yaml
+++ b/tests/loaders_test_cases/recursive_import/root.yaml
@@ -1,0 +1,1 @@
+name: root

--- a/tests/loaders_test_cases/recursive_import/root.yaml
+++ b/tests/loaders_test_cases/recursive_import/root.yaml
@@ -1,1 +1,0 @@
-name: root

--- a/tests/loaders_test_cases/recursive_import/trunk.yaml
+++ b/tests/loaders_test_cases/recursive_import/trunk.yaml
@@ -1,0 +1,2 @@
+name: root
+diameter: 20cm


### PR DESCRIPTION
## Description

Illustrating memory leak in `FileRulesLoader`, when recursive `import`'s are used.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
