### PR TITLE
Fixing loader imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - jinja2 3.0.1 to 3.0.3 - [#562](https://github.com/jertel/elastalert2/pull/562) - @nsano-rururu
 - Fix `get_rule_file_hash` TypeError - [#566](https://github.com/jertel/elastalert2/pull/566) - @JeffAshton
 - Ensure `schema.yaml` stream closed - [#567](https://github.com/jertel/elastalert2/pull/567) - @JeffAshton
+- Fixing `import` bugs & memory leak in `RulesLoader`/`FileRulesLoader` - [#580](https://github.com/jertel/elastalert2/pull/580)
 
 # 2.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - jinja2 3.0.1 to 3.0.3 - [#562](https://github.com/jertel/elastalert2/pull/562) - @nsano-rururu
 - Fix `get_rule_file_hash` TypeError - [#566](https://github.com/jertel/elastalert2/pull/566) - @JeffAshton
 - Ensure `schema.yaml` stream closed - [#567](https://github.com/jertel/elastalert2/pull/567) - @JeffAshton
-- Fixing `import` bugs & memory leak in `RulesLoader`/`FileRulesLoader` - [#580](https://github.com/jertel/elastalert2/pull/580)
+- Fixing `import` bugs & memory leak in `RulesLoader`/`FileRulesLoader` - [#580](https://github.com/jertel/elastalert2/pull/580) - @JeffAshton
 
 # 2.2.3
 

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -512,41 +512,25 @@ def test_load_yaml_recursive_import():
     branch_path = os.path.join(loaders_test_cases_path, 'recursive_import/branch.yaml')
     leaf_path = os.path.join(loaders_test_cases_path, 'recursive_import/leaf.yaml')
 
-    leaf_yaml = rules_loader.load_yaml(leaf_path)
-    assert leaf_yaml == {
-        'name': 'leaf',
-        'rule_file': leaf_path,
-        'diameter': '5cm',
-    }
-    assert sorted(rules_loader.import_rules.keys()) == [
-        branch_path,
-        leaf_path,
-    ]
-    assert rules_loader.import_rules[branch_path] == [
-        trunk_path,
-    ]
-    assert rules_loader.import_rules[leaf_path] == [
-        branch_path,
-    ]
+    # re-load the rule a couple times to ensure import_rules cache is updated correctly
+    for i in range(3):
 
-    # reload the rule
-    leaf_yaml = rules_loader.load_yaml(leaf_path)
-    assert leaf_yaml == {
-        'name': 'leaf',
-        'rule_file': leaf_path,
-        'diameter': '5cm',
-    }
-    assert sorted(rules_loader.import_rules.keys()) == [
-        branch_path,
-        leaf_path,
-    ]
-    assert rules_loader.import_rules[branch_path] == [
-        trunk_path,
-        trunk_path,  # memory leak
-    ]
-    assert rules_loader.import_rules[leaf_path] == [
-        branch_path,
-    ]
+        leaf_yaml = rules_loader.load_yaml(leaf_path)
+        assert leaf_yaml == {
+            'name': 'leaf',
+            'rule_file': leaf_path,
+            'diameter': '5cm',
+        }
+        assert sorted(rules_loader.import_rules.keys()) == [
+            branch_path,
+            leaf_path,
+        ]
+        assert rules_loader.import_rules[branch_path] == [
+            trunk_path,
+        ]
+        assert rules_loader.import_rules[leaf_path] == [
+            branch_path,
+        ]
 
 
 def test_load_yaml_multiple_imports():
@@ -557,38 +541,19 @@ def test_load_yaml_multiple_imports():
     oxygen_path = os.path.join(loaders_test_cases_path, 'multiple_imports/oxygen.yaml')
     water_path = os.path.join(loaders_test_cases_path, 'multiple_imports/water.yaml')
 
-    water_yaml = rules_loader.load_yaml(water_path)
-    assert water_yaml == {
-        'name': 'water',
-        'rule_file': water_path,
-        'symbol': 'O',
-    }
-    assert sorted(rules_loader.import_rules.keys()) == [
-        oxygen_path,
-        water_path,
-    ]
-    assert rules_loader.import_rules[oxygen_path] == [
-        hydrogen_path,
-    ]
-    assert rules_loader.import_rules[water_path] == [
-        oxygen_path,
-    ]
+    # re-load the rule a couple times to ensure import_rules cache is updated correctly
+    for i in range(3):
 
-    # reload the rule
-    water_yaml = rules_loader.load_yaml(water_path)
-    assert water_yaml == {
-        'name': 'water',
-        'rule_file': water_path,
-        'symbol': 'O',
-    }
-    assert sorted(rules_loader.import_rules.keys()) == [
-        oxygen_path,
-        water_path,
-    ]
-    assert rules_loader.import_rules[oxygen_path] == [
-        hydrogen_path,
-        hydrogen_path,  # memory leak
-    ]
-    assert rules_loader.import_rules[water_path] == [
-        oxygen_path,
-    ]
+        water_yaml = rules_loader.load_yaml(water_path)
+        assert water_yaml == {
+            'name': 'water',
+            'rule_file': water_path,
+            'symbol': 'O',
+        }
+        assert sorted(rules_loader.import_rules.keys()) == [
+            water_path,
+        ]
+        assert rules_loader.import_rules[water_path] == [
+            hydrogen_path,
+            oxygen_path,
+        ]

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -557,3 +557,73 @@ def test_load_yaml_multiple_imports():
             hydrogen_path,
             oxygen_path,
         ]
+
+
+def test_load_yaml_imports_modified():
+    config = {}
+    rules_loader = FileRulesLoader(config)
+
+    rule_path = os.path.join(empty_folder_test_path, 'rule.yaml')
+    first_import_path = os.path.join(empty_folder_test_path, 'first.yaml')
+    second_import_path = os.path.join(empty_folder_test_path, 'second.yaml')
+
+    with mock.patch.object(rules_loader, 'get_yaml') as get_yaml:
+        get_yaml.side_effect = [
+            {
+                'name': 'rule',
+                'import': first_import_path,
+            },
+            {
+                'imported': 'first',
+            }
+        ]
+        rule_yaml = rules_loader.load_yaml(rule_path)
+        assert rule_yaml == {
+            'name': 'rule',
+            'rule_file': rule_path,
+            'imported': 'first',
+        }
+        assert sorted(rules_loader.import_rules.keys()) == [
+            rule_path,
+        ]
+        assert rules_loader.import_rules[rule_path] == [
+            first_import_path
+        ]
+
+    # simulate the import changing
+    with mock.patch.object(rules_loader, 'get_yaml') as get_yaml:
+        get_yaml.side_effect = [
+            {
+                'name': 'rule',
+                'import': second_import_path,
+            },
+            {
+                'imported': 'second',
+            }
+        ]
+        rule_yaml = rules_loader.load_yaml(rule_path)
+        assert rule_yaml == {
+            'name': 'rule',
+            'rule_file': rule_path,
+            'imported': 'second',
+        }
+        assert sorted(rules_loader.import_rules.keys()) == [
+            rule_path,
+        ]
+        assert rules_loader.import_rules[rule_path] == [
+            second_import_path
+        ]
+
+    # simulate the import being removed
+    with mock.patch.object(rules_loader, 'get_yaml') as get_yaml:
+        get_yaml.side_effect = [
+            {
+                'name': 'rule',
+            },
+        ]
+        rule_yaml = rules_loader.load_yaml(rule_path)
+        assert rule_yaml == {
+            'name': 'rule',
+            'rule_file': rule_path,
+        }
+        assert len(rules_loader.import_rules) == 0


### PR DESCRIPTION
## Description

Fixing `RulesLoader`/`FileRulesLoader` to load and maintain cache of imports (`import_rules`) correctly.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
