### PR TITLE
Load Jinja template when loading an alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - TBD - [#000](https://github.com/jertel/elastalert2/pull/000) - @some_elastic_contributor_tbd
 
 ## Other changes
-- TBD - [#000](https://github.com/jertel/elastalert2/pull/000) - @some_elastic_contributor_tbd
+- Load Jinja template when loading an alert - [#654](https://github.com/jertel/elastalert2/pull/654) - @thib12
 
 # 2.3.0
 

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -465,7 +465,9 @@ class RulesLoader(object):
         if rule.get('scan_entire_timeframe') and not rule.get('timeframe'):
             raise EAException('scan_entire_timeframe can only be used if there is a timeframe specified')
 
-        # Compile Jinja Template
+        self.load_jinja_template(rule)
+
+    def load_jinja_template(self, rule):
         if rule.get('alert_text_type') == 'alert_text_jinja':
             jinja_template_path = rule.get('jinja_template_path')
             if jinja_template_path:
@@ -520,6 +522,7 @@ class RulesLoader(object):
                 name, config = next(iter(list(alert.items())))
                 config_copy = copy.copy(rule)
                 config_copy.update(config)  # warning, this (intentionally) mutates the rule dict
+                self.load_jinja_template(config_copy)
                 return name, config_copy
             else:
                 raise EAException()

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -172,6 +172,32 @@ def test_load_inline_alert_rule():
         assert 'baz@foo.bar' in test_rule_copy['alert'][1].rule['email']
 
 
+def test_load_inline_alert_rule_with_jinja():
+    rules_loader = FileRulesLoader(test_config)
+    test_rule_copy = copy.deepcopy(test_rule)
+    test_rule_copy['alert'] = [
+        {
+            'email': {
+                'alert_text_type': 'alert_text_jinja',
+                'alert_text': '{{ myjinjavar }}'
+            }
+        },
+        {
+            'email': {
+                'alert_text': 'hello'
+            }
+        }
+    ]
+    test_config_copy = copy.deepcopy(test_config)
+    with mock.patch.object(rules_loader, 'get_yaml') as mock_open:
+        mock_open.side_effect = [test_config_copy, test_rule_copy]
+        rules_loader.load_modules(test_rule_copy)
+        assert isinstance(test_rule_copy['alert'][0], EmailAlerter)
+        assert isinstance(test_rule_copy['alert'][1], EmailAlerter)
+        assert 'jinja_template' in test_rule_copy['alert'][0].rule
+        assert 'jinja_template' not in test_rule_copy['alert'][1].rule
+
+
 def test_file_rules_loader_get_names_recursive():
     conf = {'scan_subdirectories': True, 'rules_folder': empty_folder_test_path}
     rules_loader = FileRulesLoader(conf)


### PR DESCRIPTION
## Description

Load Jinja template when loading an alert. This enables using alert specific Jinja templates.
Closes #653 

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
