### PR TITLE
[Teams] - Kibana Discover URL and Facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Dockerfile refactor for app home and user home to be the same directory (/opt/elastalert/). Before app home is /opt/elastalert/ and user home is /opt/elastalert/elastalert. After app home and user home are the same /opt/elastalert/ - [#656](https://github.com/jertel/elastalert2/pull/656)
 
 ## New features
-- TBD - [#000](https://github.com/jertel/elastalert2/pull/000) - @some_elastic_contributor_tbd
+- [Teams] - Kibana Discover URL and Facts - [#660](https://github.com/jertel/elastalert2/pull/660) - @thib12
 
 ## Other changes
 - Load Jinja template when loading an alert - [#654](https://github.com/jertel/elastalert2/pull/654) - @thib12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Dockerfile refactor for app home and user home to be the same directory (/opt/elastalert/). Before app home is /opt/elastalert/ and user home is /opt/elastalert/elastalert. After app home and user home are the same /opt/elastalert/ - [#656](https://github.com/jertel/elastalert2/pull/656)
 
 ## New features
-- [Teams] - Kibana Discover URL and Facts - [#660](https://github.com/jertel/elastalert2/pull/660) - @thib12
+- [MS Teams] Kibana Discover URL and Facts - [#660](https://github.com/jertel/elastalert2/pull/660) - @thib12
 
 ## Other changes
 - Load Jinja template when loading an alert - [#654](https://github.com/jertel/elastalert2/pull/654) - @thib12

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2500,6 +2500,42 @@ Optional:
 
 ``ms_teams_alert_fixed_width``: By default this is ``False`` and the notification will be sent to MS Teams as-is. Teams supports a partial Markdown implementation, which means asterisk, underscore and other characters may be interpreted as Markdown. Currenlty, Teams does not fully implement code blocks. Setting this attribute to ``True`` will enable line by line code blocks. It is recommended to enable this to get clearer notifications in Teams.
 
+``ms_teams_alert_facts``: You can add additional facts to your MS Teams alerts using this field. Specify the title using `name` and a value for the field using `value`.
+
+Example ms_teams_alert_facts::
+
+    ms_teams_alert_facts:
+      - name: Host
+        value: monitor.host
+      - name: Status
+        value: monitor.status
+      - name: Zone
+        value: beat.name
+
+``ms_teams_attach_kibana_discover_url``: Enables the attachment of the ``kibana_discover_url`` to the MS Teams notification. The config ``generate_kibana_discover_url`` must also be ``True`` in order to generate the url. Defaults to ``False``.
+
+``ms_teams_kibana_discover_title``: The title of the Kibana Discover url attachment. Defaults to ``Discover in Kibana``.
+
+Example ms_teams_attach_kibana_discover_url, ms_teams_kibana_discover_title::
+
+    # (Required)
+    generate_kibana_discover_url: True
+    kibana_discover_app_url: "http://localhost:5601/app/discover#/"
+    kibana_discover_index_pattern_id: "4babf380-c3b1-11eb-b616-1b59c2feec54"
+    kibana_discover_version: "7.15"
+
+    # (Optional)
+    kibana_discover_from_timedelta:
+      minutes: 10
+    kibana_discover_to_timedelta:
+      minutes: 10
+
+    # (Required)
+    ms_teams_attach_kibana_discover_url: True
+
+    # (Optional)
+    ms_teams_kibana_discover_title: "Discover in Kibana"
+
 ``ms_teams_ca_certs``: Set this option to ``True`` if you want to validate the SSL certificate.
 
 ``ms_teams_ignore_ssl_errors``: By default ElastAlert 2 will verify SSL certificate. Set this option to ``False`` if you want to ignore SSL errors.

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -46,6 +46,17 @@ definitions:
     type: array
     items: *slackField
 
+  msTeamsFact: &msTeamsFact
+    type: object
+    additionalProperties: false
+    properties:
+      name: {type: string}
+      value: {type: string}
+
+  arrayOfMsTeamsFacts: &arrayOfMsTeamsFacts
+    type: array
+    items: *msTeamsFact
+
   mattermostField: &mattermostField
     type: object
     additionalProperties: false
@@ -508,6 +519,9 @@ properties:
   ms_teams_theme_color: {type: string}
   ms_teams_proxy: {type: string}
   ms_teams_alert_fixed_width: {type: boolean}
+  ms_teams_alert_facts: *arrayOfMsTeamsFacts
+  ms_teams_attach_kibana_discover_url: {type: boolean}
+  ms_teams_kibana_discover_title: {type: string}
   ms_teams_ca_certs: {type: boolean}
   ms_teams_ignore_ssl_errors: {type: boolean}
 

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -36,7 +36,7 @@ def test_ms_teams(caplog):
         '@context': 'http://schema.org/extensions',
         'summary': rule['ms_teams_alert_summary'],
         'title': rule['alert_subject'],
-        'text': BasicMatchString(rule, match).__str__()
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}]
     }
     mock_post_request.assert_called_once_with(
         rule['ms_teams_webhook_url'],
@@ -78,7 +78,7 @@ def test_ms_teams_uses_color_and_fixed_width_text():
         'summary': rule['ms_teams_alert_summary'],
         'title': rule['alert_subject'],
         'themeColor': '#124578',
-        'text': body
+        'sections': [{'text': body}]
     }
     mock_post_request.assert_called_once_with(
         rule['ms_teams_webhook_url'],
@@ -115,7 +115,7 @@ def test_ms_teams_proxy():
         '@context': 'http://schema.org/extensions',
         'summary': rule['ms_teams_alert_summary'],
         'title': rule['alert_subject'],
-        'text': BasicMatchString(rule, match).__str__()
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}]
     }
     mock_post_request.assert_called_once_with(
         rule['ms_teams_webhook_url'],
@@ -147,7 +147,7 @@ def test_ms_teams_ea_exception():
         mock_run = mock.MagicMock(side_effect=RequestException)
         with mock.patch('requests.post', mock_run), pytest.raises(RequestException):
             alert.alert([match])
-    assert 'Error posting to ms teams: ' in str(ea)
+    assert 'Error posting to MS Teams: ' in str(ea)
 
 
 def test_ms_teams_getinfo():
@@ -240,7 +240,7 @@ def test_ms_teams_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         '@context': 'http://schema.org/extensions',
         'summary': rule['ms_teams_alert_summary'],
         'title': rule['alert_subject'],
-        'text': BasicMatchString(rule, match).__str__()
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}]
     }
     mock_post_request.assert_called_once_with(
         rule['ms_teams_webhook_url'],
@@ -248,5 +248,198 @@ def test_ms_teams_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         headers={'content-type': 'application/json'},
         proxies=None,
         verify=excpet_verify
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
+def test_ms_teams_attach_kibana_discover_url_when_generated():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_teams_attach_kibana_discover_url': True,
+        'ms_teams_webhook_url': 'http://test.webhook.url',
+        'ms_teams_alert_summary': 'Alert from ElastAlert',
+        'alert': [],
+        'alert_subject': 'Cool subject',
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsTeamsAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        'summary': rule['ms_teams_alert_summary'],
+        'title': rule['alert_subject'],
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}],
+        'potentialAction': [
+            {
+                '@type': 'OpenUri',
+                'name': 'Discover in Kibana',
+                'targets': [
+                    {
+                        'os': 'default',
+                        'uri': 'http://kibana#discover',
+                    }
+                ],
+            }
+        ],
+    }
+    mock_post_request.assert_called_once_with(
+        rule['ms_teams_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_ms_teams_attach_kibana_discover_url_when_not_generated():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_teams_attach_kibana_discover_url': True,
+        'ms_teams_webhook_url': 'http://test.webhook.url',
+        'ms_teams_alert_summary': 'Alert from ElastAlert',
+        'alert': [],
+        'alert_subject': 'Cool subject',
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsTeamsAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        'summary': rule['ms_teams_alert_summary'],
+        'title': rule['alert_subject'],
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}],
+    }
+    mock_post_request.assert_called_once_with(
+        rule['ms_teams_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_ms_teams_kibana_discover_title():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_teams_attach_kibana_discover_url': True,
+        'ms_teams_kibana_discover_title': 'Click to discover in Kibana',
+        'ms_teams_webhook_url': 'http://test.webhook.url',
+        'ms_teams_alert_summary': 'Alert from ElastAlert',
+        'alert': [],
+        'alert_subject': 'Cool subject',
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsTeamsAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        'summary': rule['ms_teams_alert_summary'],
+        'title': rule['alert_subject'],
+        'sections': [{'text': BasicMatchString(rule, match).__str__()}],
+        'potentialAction': [
+            {
+                '@type': 'OpenUri',
+                'name': 'Click to discover in Kibana',
+                'targets': [
+                    {
+                        'os': 'default',
+                        'uri': 'http://kibana#discover',
+                    }
+                ],
+            }
+        ],
+    }
+    mock_post_request.assert_called_once_with(
+        rule['ms_teams_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_ms_teams_alert_facts():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_teams_webhook_url': 'http://test.webhook.url',
+        'ms_teams_alert_summary': 'Alert from ElastAlert',
+        'ms_teams_alert_facts': [
+            {
+                'name': 'Host',
+                'value': 'somefield',
+            },
+            {
+                'name': 'Sensors',
+                'value': '@timestamp',
+            }
+        ],
+        'alert_subject': 'Cool subject',
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsTeamsAlerter(rule)
+    match = {
+        '@timestamp': '2016-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        'summary': rule['ms_teams_alert_summary'],
+        'title': rule['alert_subject'],
+        'sections': [
+            {
+                'text': BasicMatchString(rule, match).__str__(),
+                'facts': [
+                    {'name': 'Host', 'value': 'foobarbaz'},
+                    {'name': 'Sensors', 'value': '2016-01-01T00:00:00'},
+                ],
+            }
+        ],
+    }
+
+    mock_post_request.assert_called_once_with(
+        rule['ms_teams_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

Just as the Slack alerter supports Kibana Discover URL and Fields, we add these features to the MS Teams alerter. Note that MS Teams does not have _fields_ but _facts_ in their jargon.
 
## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
