### PR TITLE
Add metric_agg_value to match_body of MetricAggregationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ## New features
 - [MS Teams] Kibana Discover URL and Facts - [#660](https://github.com/jertel/elastalert2/pull/660) - @thib12
 - Add support for Kibana 7.17 for Kibana Discover - [#695](https://github.com/jertel/elastalert2/pull/695) - @nsano-rururu
-
+- Added a fixed name metric_agg_value to MetricAggregationRule match_body - [#697](https://github.com/jertel/elastalert2/pull/697) - @iamxeph
 ## Other changes
 - Load Jinja template when loading an alert - [#654](https://github.com/jertel/elastalert2/pull/654) - @thib12
 - tox 3.24.4 to 3.24.5 - [#655](https://github.com/jertel/elastalert2/pull/655) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1323,6 +1323,8 @@ supported by the specified aggregation type.  If using a scripted field via ``me
 ``metric_agg_type``: The type of metric aggregation to perform on the ``metric_agg_key`` field. This must be one of 'min', 'max', 'avg',
 'sum', 'cardinality', 'value_count'.
 
+.. note:: When Metric Aggregation has a match, match_body includes an aggregated value that triggered the match so that you can use that on an alert. The value is named based on ``metric_agg_key`` and ``metric_agg_type``. For example, if you set ``metric_agg_key`` to 'system.cpu.total.norm.pct' and ``metric_agg_type`` to 'avg', the name of the value is 'metric_system.cpu.total.norm.pct_avg'. Because of this naming rule, you might face conflicts with jinja2 template, and when that happens, you also can use 'metric_agg_value' from match_body instead.
+
 ``doc_type``: Specify the ``_type`` of document to search for.
 
 This rule also requires at least one of the two following options:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1106,10 +1106,13 @@ class MetricAggregationRule(BaseAggregationRule):
                 metric_val = aggregation_data[self.metric_key]['value']
             if self.crossed_thresholds(metric_val):
                 match = {self.rules['timestamp_field']: timestamp,
-                         self.metric_key: metric_val}
+                         self.metric_key: metric_val,
+                         'metric_agg_value': metric_val
+                         }
                 metric_format_string = self.rules.get('metric_format_string', None)
                 if metric_format_string is not None:
                     match[self.metric_key +'_formatted'] = format_string(metric_format_string, metric_val)
+                    match['metric_agg_value_formatted'] = format_string(metric_format_string, metric_val)
                 if query_key is not None:
                     match = expand_string_into_dict(match, self.rules['query_key'], query_key)
                 self.add_match(match)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -1177,19 +1177,27 @@ def test_metric_aggregation():
     rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
     assert '0.966666667' in rule.get_match_str(rule.matches[0])
     assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert rule.matches[0]['metric_agg_value'] == 0.966666667
     assert 'metric_cpu_pct_avg_formatted' not in rule.matches[0]
+    assert 'metric_agg_value_formatted' not in rule.matches[0]
+
     rules['metric_format_string'] = '{:.2%}'
     rule = MetricAggregationRule(rules)
     rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
     assert '96.67%' in rule.get_match_str(rule.matches[0])
     assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert rule.matches[0]['metric_agg_value'] == 0.966666667
     assert rule.matches[0]['metric_cpu_pct_avg_formatted'] == '96.67%'
+    assert rule.matches[0]['metric_agg_value_formatted'] == '96.67%'
+
     rules['metric_format_string'] = '%.2f'
     rule = MetricAggregationRule(rules)
     rule.check_matches(datetime.datetime.now(), None, {'metric_cpu_pct_avg': {'value': 0.966666667}})
     assert '0.97' in rule.get_match_str(rule.matches[0])
     assert rule.matches[0]['metric_cpu_pct_avg'] == 0.966666667
+    assert rule.matches[0]['metric_agg_value'] == 0.966666667
     assert rule.matches[0]['metric_cpu_pct_avg_formatted'] == '0.97'
+    assert rule.matches[0]['metric_agg_value_formatted'] == '0.97'
 
     rules['query_key'] = 'subdict'
     rule = MetricAggregationRule(rules)


### PR DESCRIPTION
## Description

This PR adds 'metric_agg_value' to match_body of MetricAggregationRule so that users can use jinja2 template to create alert_subject, alert_text with MetricAggregationRule. 

Jinja2 template engine sees strings with dot(s) as dot-annotation dictionary, so if you want to use a variable named 'metric_system.cpu.total.norm.pct_avg' with jinja2 template {{ metric_system.cpu.total.norm.pct_avg }}, it is looking for metric_system['cpu']['total']['norm']['pct_avg'] which causes an exception saying metric_system is undefined, obviously.

By adding 'metric_agg_value' to match_body, users can use jinja2 template {{ metric_agg_value }} instead.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments
I will continue to work on docs and changelogs once you agree with this