### PR TITLE
Enable loading ElastAlert2 against a fresh ES8 instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Docs] Update of RuleType Configuration Cheat Sheet - [#707](https://github.com/jertel/elastalert2/pull/707) - @nsano-rururu
 - Pytest 7.0.0 to 7.0.1 - [#710](https://github.com/jertel/elastalert2/pull/710) - @nsano-rururu
 - Fixing jira_transition_to schema bug. Change property type from boolean to string [#721](https://github.com/jertel/elastalert2/pull/721) - @toxisch
+- Begin Elasticsearch 8 support - ElastAlert 2 now supports setup with fresh ES 8 instances, and works with some alert types [#731](https://github.com/jertel/elastalert2/pull/731) - @ferozsalam
 
 # 2.3.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt -y upgrade && \
     echo "set -e" >> /opt/elastalert/run.sh && \
     echo "elastalert-create-index --config /opt/elastalert/config.yaml" \
         >> /opt/elastalert/run.sh && \
-    echo "elastalert --config /opt/elastalert/config.yaml \"\$@\"" \
+    echo "elastalert --debug --config /opt/elastalert/config.yaml \"\$@\"" \
         >> /opt/elastalert/run.sh && \
     chmod +x /opt/elastalert/run.sh && \
     groupadd -g ${GID} ${USERNAME} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt -y upgrade && \
     echo "set -e" >> /opt/elastalert/run.sh && \
     echo "elastalert-create-index --config /opt/elastalert/config.yaml" \
         >> /opt/elastalert/run.sh && \
-    echo "elastalert --debug --config /opt/elastalert/config.yaml \"\$@\"" \
+    echo "elastalert --config /opt/elastalert/config.yaml \"\$@\"" \
         >> /opt/elastalert/run.sh && \
     chmod +x /opt/elastalert/run.sh && \
     groupadd -g ${GID} ${USERNAME} && \

--- a/elastalert/__init__.py
+++ b/elastalert/__init__.py
@@ -95,6 +95,13 @@ class ElasticSearchClient(Elasticsearch):
         """
         return int(self.es_version.split(".")[0]) >= 7
 
+    def is_atleasteight(self):
+        """
+        Returns True when the Elasticsearch server version >= 8
+        """
+        return int(self.es_version.split(".")[0]) >= 8
+
+
     def resolve_writeback_index(self, writeback_index, doc_type):
         """ In ES6, you cannot have multiple _types per index,
         therefore we use self.writeback_index as the prefix for the actual

--- a/elastalert/es_mappings/8/elastalert.json
+++ b/elastalert/es_mappings/8/elastalert.json
@@ -1,0 +1,39 @@
+{
+  "numeric_detection": true,
+  "date_detection": false,
+  "dynamic_templates": [
+    {
+      "strings_as_keyword": {
+        "mapping": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "match_mapping_type": "string"
+      }
+    }
+  ],
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "date_optional_time"
+    },
+    "alert_time": {
+      "type": "date",
+      "format": "date_optional_time"
+    },
+    "match_time": {
+      "type": "date",
+      "format": "date_optional_time"
+    },
+    "match_body": {
+      "enabled": "false",
+      "type": "object"
+    },
+    "aggregate_id": {
+      "type": "keyword"
+    }
+  }
+}

--- a/elastalert/es_mappings/8/elastalert_error.json
+++ b/elastalert/es_mappings/8/elastalert_error.json
@@ -1,0 +1,12 @@
+{
+  "properties": {
+    "data": {
+      "type": "object",
+      "enabled": "false"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "date_optional_time"
+    }
+  }
+}

--- a/elastalert/es_mappings/8/elastalert_status.json
+++ b/elastalert/es_mappings/8/elastalert_status.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "date_optional_time"
+    }
+  }
+}

--- a/elastalert/es_mappings/8/past_elastalert.json
+++ b/elastalert/es_mappings/8/past_elastalert.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "match_body": {
+      "type": "object",
+      "enabled": "false"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "date_optional_time"
+    },
+    "aggregate_id": {
+      "type": "keyword"
+    }
+  }
+}

--- a/elastalert/es_mappings/8/silence.json
+++ b/elastalert/es_mappings/8/silence.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "until": {
+      "type": "date",
+      "format": "date_optional_time"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "date_optional_time"
+    }
+  }
+}

--- a/tests/create_index_test.py
+++ b/tests/create_index_test.py
@@ -53,6 +53,12 @@ def test_read_es_6_index_mappings():
     print((json.dumps(mappings, indent=2)))
 
 
+def test_read_es_8_index_mappings():
+    mappings = elastalert.create_index.read_es_index_mappings(8)
+    assert len(mappings) == len(es_mappings)
+    print((json.dumps(mappings, indent=2)))
+
+
 @pytest.mark.parametrize('es_version, expected', [
     ('5.6.0', False),
     ('6.0.0', True),
@@ -143,4 +149,18 @@ def test_is_atleastsixtwo(es_version, expected):
 ])
 def test_is_atleastseven(es_version, expected):
     result = elastalert.create_index.is_atleastseven(es_version)
+    assert result == expected
+
+
+@pytest.mark.parametrize('es_version, expected', [
+    ('5.6.0', False),
+    ('6.0.0', False),
+    ('6.1.0', False),
+    ('7.0.0', False),
+    ('7.1.0', False),
+    ('7.17.0', False),
+    ('8.0.0', True)
+])
+def test_is_atleasteight(es_version, expected):
+    result = elastalert.create_index.is_atleasteight(es_version)
     assert result == expected


### PR DESCRIPTION
## Description

Provide mappings and `create_index.py` updates for Elasticsearch 8.

This allows ElastAlert 2 to load *against a fresh instance of Elasticsearch 8* (where no previous ElastAlert instance has been running).

Some functionality and rule types still might not work. Changes to make these work will be coming soon.

No functionality changes for ES 7.* and below.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

@jertel as stated above, this PR doesn't provide full compatibility yet, but provides first steps for fixing the various pieces that need fixing. Do you want to merge this in directly, or do you want to wait until more work has been done?

I don't have strong opinions in either direction, but it might be easier for others to contribute if the changes are made incrementally rather than all at once.
