### PR TITLE
do not install the tests with pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
 - Pytest 7.0.0 to 7.0.1 - [#710](https://github.com/jertel/elastalert2/pull/710) - @nsano-rururu
 - Fixing jira_transition_to schema bug. Change property type from boolean to string [#721](https://github.com/jertel/elastalert2/pull/721) - @toxisch
 - Begin Elasticsearch 8 support - ElastAlert 2 now supports setup with fresh ES 8 instances, and works with some alert types [#731](https://github.com/jertel/elastalert2/pull/731) - @ferozsalam
-- Enable dynamic setting of rules volume in helm chart [#732] - @ChrisFraun
+- Enable dynamic setting of rules volume in helm chart [#732](https://github.com/jertel/elastalert2/pull/732) - @ChrisFraun
+- Do not install tests via pip install [#733](https://github.com/jertel/elastalert2/pull/733) - @buzzdeee
 
 
 # 2.3.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
                             'elastalert-test-rule=elastalert.test_rule:main',
                             'elastalert-rule-from-kibana=elastalert.rule_from_kibana:main',
                             'elastalert=elastalert.elastalert:main']},
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     package_data={'elastalert': ['schema.yaml', 'es_mappings/**/*.json']},
     install_requires=[
         'apscheduler>=3.8.1,<4.0',


### PR DESCRIPTION
## Description

Installing elastalert2 via pip also installs the tests subdirectory, which clutters up the system.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments


