### PR TITLE
[MS Teams] Add arbitrary text value support for Facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- [MS Teams] Add arbitrary text value support for Facts - [#790](https://github.com/jertel/elastalert2/pull/790) - @iamxeph
+- TBD - [#000](https://github.com/jertel/elastalert2/pull/000) - @some_elastic_contributor_tbd
 
 ## Other changes
 - None
@@ -15,6 +15,7 @@
 
 ## New features
 - Add support for Kibana 8.1 for Kibana Discover - [#763](https://github.com/jertel/elastalert2/pull/763) - @nsano-rururu
+- [MS Teams] Add arbitrary text value support for Facts - [#790](https://github.com/jertel/elastalert2/pull/790) - @iamxeph
 
 ## Other changes
 - [Docs] Update FAQ ssl_show_warn - [#764](https://github.com/jertel/elastalert2/pull/764) - @nsano-rururu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- [MS Teams] Add arbitrary text value support for Facts - [#000](https://github.com/jertel/elastalert2/pull/000) - @iamxeph
+- [MS Teams] Add arbitrary text value support for Facts - [#790](https://github.com/jertel/elastalert2/pull/790) - @iamxeph
 
 ## Other changes
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- TBD - [#000](https://github.com/jertel/elastalert2/pull/000) - @some_elastic_contributor_tbd
+- [MS Teams] Add arbitrary text value support for Facts - [#000](https://github.com/jertel/elastalert2/pull/000) - @iamxeph
 
 ## Other changes
 - None

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2596,7 +2596,7 @@ Optional:
 
 ``ms_teams_alert_fixed_width``: By default this is ``False`` and the notification will be sent to MS Teams as-is. Teams supports a partial Markdown implementation, which means asterisk, underscore and other characters may be interpreted as Markdown. Currenlty, Teams does not fully implement code blocks. Setting this attribute to ``True`` will enable line by line code blocks. It is recommended to enable this to get clearer notifications in Teams.
 
-``ms_teams_alert_facts``: You can add additional facts to your MS Teams alerts using this field. Specify the title using `name` and a value for the field using `value`.
+``ms_teams_alert_facts``: You can add additional facts to your MS Teams alerts using this field. Specify the title using `name` and a value for the field or arbitrary text using `value`. 
 
 Example ms_teams_alert_facts::
 
@@ -2605,8 +2605,8 @@ Example ms_teams_alert_facts::
         value: monitor.host
       - name: Status
         value: monitor.status
-      - name: Zone
-        value: beat.name
+      - name: What to do
+        value: Page your boss
 
 ``ms_teams_attach_kibana_discover_url``: Enables the attachment of the ``kibana_discover_url`` to the MS Teams notification. The config ``generate_kibana_discover_url`` must also be ``True`` in order to generate the url. Defaults to ``False``.
 

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -37,7 +37,7 @@ class MsTeamsAlerter(Alerter):
         for arg in self.ms_teams_alert_facts:
             arg = copy.copy(arg)
             matched_value = lookup_es_key(matches[0], arg['value'])
-            arg['value'] = matched_value if matched_value else arg['value']
+            arg['value'] = matched_value if matched_value is not None else arg['value']
             alert_facts.append(arg)
         return alert_facts
 

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -36,7 +36,8 @@ class MsTeamsAlerter(Alerter):
         alert_facts = []
         for arg in self.ms_teams_alert_facts:
             arg = copy.copy(arg)
-            arg['value'] = lookup_es_key(matches[0], arg['value'])
+            matched_value = lookup_es_key(matches[0], arg['value'])
+            arg['value'] = matched_value if matched_value else arg['value']
             alert_facts.append(arg)
         return alert_facts
 

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -406,8 +406,8 @@ def test_ms_teams_alert_facts():
                 'value': '@timestamp',
             },
             {
-                'name': 'You Cannot Find Me',
-                'value': 'I Told You'
+                'name': 'Arbitrary Text Name',
+                'value': 'Arbitrary Text Value'
             }
         ],
         'alert_subject': 'Cool subject',
@@ -434,7 +434,7 @@ def test_ms_teams_alert_facts():
                 'facts': [
                     {'name': 'Host', 'value': 'foobarbaz'},
                     {'name': 'Sensors', 'value': '2016-01-01T00:00:00'},
-                    {'name': 'You Cannot Find Me', 'value': 'I Told You'}
+                    {'name': 'Arbitrary Text Name', 'value': 'Arbitrary Text Value'}
                 ],
             }
         ],

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -404,6 +404,10 @@ def test_ms_teams_alert_facts():
             {
                 'name': 'Sensors',
                 'value': '@timestamp',
+            },
+            {
+                'name': 'You Cannot Find Me',
+                'value': 'I Told You'
             }
         ],
         'alert_subject': 'Cool subject',
@@ -430,6 +434,7 @@ def test_ms_teams_alert_facts():
                 'facts': [
                     {'name': 'Host', 'value': 'foobarbaz'},
                     {'name': 'Sensors', 'value': '2016-01-01T00:00:00'},
+                    {'name': 'You Cannot Find Me', 'value': 'I Told You'}
                 ],
             }
         ],

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -399,11 +399,23 @@ def test_ms_teams_alert_facts():
         'ms_teams_alert_facts': [
             {
                 'name': 'Host',
-                'value': 'somefield',
+                'value': 'somefield'
             },
             {
                 'name': 'Sensors',
-                'value': '@timestamp',
+                'value': '@timestamp'
+            },
+            {
+                'name': 'Speed',
+                'value': 'vehicle.speed'
+            },
+            {
+                'name': 'Boolean',
+                'value': 'boolean'
+            },
+            {
+                'name': 'Blank',
+                'value': 'blank'
             },
             {
                 'name': 'Arbitrary Text Name',
@@ -418,8 +430,14 @@ def test_ms_teams_alert_facts():
     alert = MsTeamsAlerter(rule)
     match = {
         '@timestamp': '2016-01-01T00:00:00',
-        'somefield': 'foobarbaz'
+        'somefield': 'foobarbaz',
+        'vehicle': {
+            'speed': 0,
+        },
+        'boolean': False,
+        'blank': ''
     }
+
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
 
@@ -434,6 +452,9 @@ def test_ms_teams_alert_facts():
                 'facts': [
                     {'name': 'Host', 'value': 'foobarbaz'},
                     {'name': 'Sensors', 'value': '2016-01-01T00:00:00'},
+                    {'name': 'Speed', 'value': 0},
+                    {'name': 'Boolean', 'value': False},
+                    {'name': 'Blank', 'value': ''},
                     {'name': 'Arbitrary Text Name', 'value': 'Arbitrary Text Value'}
                 ],
             }


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

Make ms_teams_alert_facts have arbitrary text value for its 'value' by returning 'value' itself

Let's say you have configured the alerter like this:
```
alert_subject: "Test Alert for ElastAlert2"
alert_text: "body"
alert_text_type: alert_text_only
ms_teams_alert_facts:
  - name: Host
    value: agent.name
  - name: What to do
    value: Page your boss
```

Currently it outputs to MS Teams like this:

![image](https://user-images.githubusercontent.com/5084248/160803582-44149a60-64ab-4ae5-bfff-d3766eea26fc.png)


This PR change the output to this:

![image](https://user-images.githubusercontent.com/5084248/160803619-97be6a8e-ea3a-472c-a472-faa167dc4f4d.png)


## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
