### PR TITLE
Remove Simple Alerter

### DIFF
--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -293,8 +293,6 @@ class RulesLoader(object):
         :param filename: Name of the rule
         :param args: Arguments
         """
-        self.adjust_deprecated_values(rule)
-
         try:
             self.rule_schema.validate(rule)
         except jsonschema.ValidationError as e:
@@ -528,18 +526,6 @@ class RulesLoader(object):
             raise EAException('Error initiating alert %s: %s' % (rule['alert'], e)).with_traceback(sys.exc_info()[2])
 
         return alert_field
-
-    @staticmethod
-    def adjust_deprecated_values(rule):
-        # From rename of simple HTTP alerter
-        if rule.get('type') == 'simple':
-            rule['type'] = 'post'
-            if 'simple_proxy' in rule:
-                rule['http_post_proxy'] = rule['simple_proxy']
-            if 'simple_webhook_url' in rule:
-                rule['http_post_url'] = rule['simple_webhook_url']
-            elastalert_logger.warning(
-                '"simple" alerter has been renamed "post" and comptability may be removed in a future release.')
 
 
 class FileRulesLoader(RulesLoader):

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -294,10 +294,6 @@ properties:
   timestamp_field: {type: string}
   field: {}
 
-  ### Simple
-  simple_webhook_url: *arrayOfString
-  simple_proxy: {type: string}
-
   ### Alerta
   alerta_api_url: {type: string}
   alerta_api_key: {type: string}


### PR DESCRIPTION
## Description
With the addition of the HTTP POST alerter, we will remove the Simple Alerter that hasn't been documented for quite some time. I searched for the original yelp / elastalert issue, but none of the users were asking about Simple Alerter.
<!--
Provide a description for your pull request. Note any breaking changes.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
