### PR TITLE
[MS Teams] Use alert_subject as ms_teams_alert_summary unless set otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## New features
 - Add support for Kibana 8.1 for Kibana Discover - [#763](https://github.com/jertel/elastalert2/pull/763) - @nsano-rururu
 - [MS Teams] Add arbitrary text value support for Facts - [#790](https://github.com/jertel/elastalert2/pull/790) - @iamxeph
+- [MS Teams] Use alert_subject as ms_teams_alert_summary if ms_teams_alert_summary is not set - [#802](https://github.com/jertel/elastalert2/pull/802) - @iamxeph
 
 ## Other changes
 - [Docs] Update FAQ ssl_show_warn - [#764](https://github.com/jertel/elastalert2/pull/764) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2588,7 +2588,7 @@ menu in your channel and configure an Incoming Webhook, then copy the resulting 
 
 Optional:
 
-``ms_teams_alert_summary``: MS Teams use this value for notification title, defaults to ``Alert Subject``. You can set this value with arbitrary text if you want to display notification title other than default ``Alert Subject``.
+``ms_teams_alert_summary``: MS Teams use this value for notification title, defaults to ``Alert Subject``. You can set this value with arbitrary text if you want to display notification title other than default `Alert Subject <https://elastalert2.readthedocs.io/en/latest/ruletypes.html#alert-subject>`_.
 
 ``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2588,7 +2588,7 @@ menu in your channel and configure an Incoming Webhook, then copy the resulting 
 
 Optional:
 
-``ms_teams_alert_summary``: Summary should be configured according to `MS documentation <https://docs.microsoft.com/en-us/outlook/actionable-messages/card-reference>`_, although it seems not displayed by Teams currently, defaults to ``ElastAlert Message``.
+``ms_teams_alert_summary``: MS Teams use this value for notification title, defaults to ``Alert Subject``. You can set this value with arbitrary text if you want to display notification title other than default ``Alert Subject``.
 
 ``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
 
@@ -2640,7 +2640,6 @@ Example usage::
 
     alert:
       - "ms_teams"
-    ms_teams_alert_summary: "Alert"
     ms_teams_theme_color: "#6600ff"
     ms_teams_webhook_url: "MS Teams Webhook URL"
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2588,7 +2588,7 @@ menu in your channel and configure an Incoming Webhook, then copy the resulting 
 
 Optional:
 
-``ms_teams_alert_summary``: MS Teams use this value for notification title, defaults to ``Alert Subject``. You can set this value with arbitrary text if you want to display notification title other than default `Alert Subject <https://elastalert2.readthedocs.io/en/latest/ruletypes.html#alert-subject>`_.
+``ms_teams_alert_summary``: MS Teams use this value for notification title, defaults to `Alert Subject <https://elastalert2.readthedocs.io/en/latest/ruletypes.html#alert-subject>`_. You can set this value with arbitrary text if you don't want to use the default.
 
 ``ms_teams_theme_color``: By default the alert will be posted without any color line. To add color, set this attribute to a HTML color value e.g. ``#ff0000`` for red.
 

--- a/elastalert/alerters/teams.py
+++ b/elastalert/alerters/teams.py
@@ -17,7 +17,7 @@ class MsTeamsAlerter(Alerter):
         if isinstance(self.ms_teams_webhook_url, str):
             self.ms_teams_webhook_url = [self.ms_teams_webhook_url]
         self.ms_teams_proxy = self.rule.get('ms_teams_proxy', None)
-        self.ms_teams_alert_summary = self.rule.get('ms_teams_alert_summary', 'ElastAlert Message')
+        self.ms_teams_alert_summary = self.rule.get('ms_teams_alert_summary', None)
         self.ms_teams_alert_fixed_width = self.rule.get('ms_teams_alert_fixed_width', False)
         self.ms_teams_theme_color = self.rule.get('ms_teams_theme_color', '')
         self.ms_teams_ca_certs = self.rule.get('ms_teams_ca_certs')
@@ -43,8 +43,10 @@ class MsTeamsAlerter(Alerter):
 
     def alert(self, matches):
         body = self.create_alert_body(matches)
-
         body = self.format_body(body)
+
+        title = self.create_title(matches)
+        summary = title if self.ms_teams_alert_summary is None else self.ms_teams_alert_summary
         # post to Teams
         headers = {'content-type': 'application/json'}
 
@@ -60,8 +62,8 @@ class MsTeamsAlerter(Alerter):
         payload = {
             '@type': 'MessageCard',
             '@context': 'http://schema.org/extensions',
-            'summary': self.ms_teams_alert_summary,
-            'title': self.create_title(matches),
+            'summary': summary ,
+            'title': title,
             'sections': [{'text': body}],
         }
 

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -510,4 +510,3 @@ def test_ms_teams_alert_summary_none():
         verify=True
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
-    


### PR DESCRIPTION
## Description

ms_teams_alert_summary is actually being used in MS Teams for notification title, so it is better to use alert_subject as its default. 

For backward compatibility, this PR changes its default to None, and in the alerter code, if ms_teams_alert_summary is None, it will use alert_subject as its value instead. 

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
