### PR TITLE
Update documentation about Cloud ID support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix SpikeRule - [#804](https://github.com/jertel/elastalert2/pull/804) - @nsano-rururu
 - [Kubernetes] Add scanSubdirectories (defaults to true) as an option in Helm Chart - [#805](https://github.com/jertel/elastalert2/pull/805) - @louzadod
 - Upgrade pylint 2.13.4 to 2.13.5 - [#808](https://github.com/jertel/elastalert2/pull/808) - @nsano-rururu
+- Update documentation on Cloud ID support - [#810](https://github.com/jertel/elastalert2/pull/810) - @ferozsalam
 
 # 2.4.0
 

--- a/docs/source/recipes/faq-md.md
+++ b/docs/source/recipes/faq-md.md
@@ -277,7 +277,8 @@ threshold.
 Does it support Elastic Cloud's "Cloud ID"?
 ==========
 
-Cloud ID is not currently supported.
+While Elastic Cloud is supported via the traditional URL connection method,
+connecting via Cloud ID is not currently supported.
 
 I need to go through an http (s) proxy to connect to Elasticsearch. Does ElastAlert 2 support it?
 ==========

--- a/docs/source/recipes/faq-md.md
+++ b/docs/source/recipes/faq-md.md
@@ -277,10 +277,7 @@ threshold.
 Does it support Elastic Cloud's "Cloud ID"?
 ==========
 
-Not supported.
-
-In addition, there is a reason why we cannot handle it at present.
-ElastAlert 2 uses elasticsearch-py 7.0.0, because Elastic Cloud cloud_id support is from elasticsearch-py 7.0.2. 
+Cloud ID is not currently supported.
 
 I need to go through an http (s) proxy to connect to Elasticsearch. Does ElastAlert 2 support it?
 ==========


### PR DESCRIPTION
## Description

We have an updated version of elasticsearch-py now, so we could support Elastic
Cloud. Update the documentation to reflect that.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- N/A – I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- N/A – I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

