### PR TITLE
Change Zabbix alerter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [MS Teams] Add arbitrary text value support for Facts - [#790](https://github.com/jertel/elastalert2/pull/790) - @iamxeph
 - [MS Teams] Use alert_subject as ms_teams_alert_summary if ms_teams_alert_summary is not set - [#802](https://github.com/jertel/elastalert2/pull/802) - @iamxeph
 - [Mattermost] List support for mattermost_channel_override - [#809](https://github.com/jertel/elastalert2/pull/809) - @nsano-rururu
+- [Zabbix] Add the ability to specify `zbx_host` from available elasticsearch field - [#820](https://github.com/jertel/elastalert2/pull/820) - @timeforplanb123
 
 ## Other changes
 - [Docs] Update FAQ ssl_show_warn - [#764](https://github.com/jertel/elastalert2/pull/764) - @nsano-rururu
@@ -37,6 +38,8 @@
 - Update documentation on Cloud ID support - [#810](https://github.com/jertel/elastalert2/pull/810) - @ferozsalam
 - Upgrade tox 3.24.5 to 3.25.0 - [#813](https://github.com/jertel/elastalert2/pull/813) - @nsano-rururu
 - [Kubernetes] Add support to specify rules directory - [#816](https://github.com/jertel/elastalert2/pull/816) @SBe
+- [Docs] Update Zabbix section - [#820](https://github.com/jertel/elastalert2/pull/820) - @timeforplanb123
+- [Tests] Add new tests to zabbix_test.py for new `zbx_host_from_field` option - [#820](https://github.com/jertel/elastalert2/pull/820) - @timeforplanb123
 
 # 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@
 - Update documentation on Cloud ID support - [#810](https://github.com/jertel/elastalert2/pull/810) - @ferozsalam
 - Upgrade tox 3.24.5 to 3.25.0 - [#813](https://github.com/jertel/elastalert2/pull/813) - @nsano-rururu
 - [Kubernetes] Add support to specify rules directory - [#816](https://github.com/jertel/elastalert2/pull/816) @SBe
-- [Docs] Update Zabbix section - [#820](https://github.com/jertel/elastalert2/pull/820) - @timeforplanb123
-- [Tests] Add new tests to zabbix_test.py for new `zbx_host_from_field` option - [#820](https://github.com/jertel/elastalert2/pull/820) - @timeforplanb123
 
 # 2.4.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3324,6 +3324,8 @@ Required:
 
 ``zbx_sender_port``: The port where zabbix server is listenning, defaults to ``10051``.
 
+``zbx_host_from_field``: This field allows to specify ``zbx_host`` value from the available terms. Defaults to ``False``.
+
 ``zbx_host``: This field setup the host in zabbix that receives the value sent by ElastAlert 2.
 
 ``zbx_key``: This field setup the key in the host that receives the value sent by ElastAlert 2.
@@ -3336,3 +3338,17 @@ Example usage::
     zbx_sender_port: 10051
     zbx_host: "test001"
     zbx_key: "sender_load1"
+
+To specify ``zbx_host`` depending on the available elasticsearch field, zabbix alerter has ``zbx_host_from_field`` option.
+
+Example usage::
+
+    alert:
+      - "zabbix"
+    zbx_sender_host: "zabbix-server"
+    zbx_sender_port: 10051
+    zbx_host_from_field: True 
+    zbx_host: "hostname"
+    zbx_key: "sender_load1"
+
+where ``hostname`` is the available elasticsearch field.

--- a/elastalert/alerters/zabbix.py
+++ b/elastalert/alerters/zabbix.py
@@ -7,15 +7,9 @@ from elastalert.util import elastalert_logger, lookup_es_key, EAException
 
 
 class ZabbixClient(ZabbixAPI):
-    def __init__(
-        self,
-        url="http://localhost",
-        use_authenticate=False,
-        user="Admin",
-        password="zabbix",
-        sender_host="localhost",
-        sender_port=10051,
-    ):
+
+    def __init__(self, url='http://localhost', use_authenticate=False, user='Admin', password='zabbix',
+                 sender_host='localhost', sender_port=10051):
         self.url = url
         self.use_authenticate = use_authenticate
         self.sender_host = sender_host
@@ -23,33 +17,26 @@ class ZabbixClient(ZabbixAPI):
         self.metrics_chunk_size = 200
         self.aggregated_metrics = []
 
-        super(ZabbixClient, self).__init__(
-            url=self.url,
-            use_authenticate=self.use_authenticate,
-            user=user,
-            password=password,
-        )
+        super(ZabbixClient, self).__init__(url=self.url,
+                                           use_authenticate=self.use_authenticate,
+                                           user=user,
+                                           password=password)
 
     def send_metric(self, hostname, key, data):
         zm = ZabbixMetric(hostname, key, data)
         if self.send_aggregated_metrics:
             self.aggregated_metrics.append(zm)
             if len(self.aggregated_metrics) > self.metrics_chunk_size:
-                elastalert_logger.info(
-                    "Sending: %s metrics" % (len(self.aggregated_metrics))
-                )
+                elastalert_logger.info("Sending: %s metrics" % (len(self.aggregated_metrics)))
                 try:
-                    ZabbixSender(
-                        zabbix_server=self.sender_host, zabbix_port=self.sender_port
-                    ).send(self.aggregated_metrics)
+                    ZabbixSender(zabbix_server=self.sender_host, zabbix_port=self.sender_port) \
+                        .send(self.aggregated_metrics)
                     self.aggregated_metrics = []
                 except Exception as e:
                     elastalert_logger.exception(e)
         else:
             try:
-                ZabbixSender(
-                    zabbix_server=self.sender_host, zabbix_port=self.sender_port
-                ).send([zm])
+                ZabbixSender(zabbix_server=self.sender_host, zabbix_port=self.sender_port).send([zm])
             except Exception as e:
                 elastalert_logger.exception(e)
 
@@ -59,21 +46,19 @@ class ZabbixAlerter(Alerter):
     # You can ensure that the rule config file specifies all
     # of the options. Otherwise, ElastAlert will throw an exception
     # when trying to load the rule.
-    required_options = frozenset(["zbx_host", "zbx_key"])
+    required_options = frozenset(['zbx_host', 'zbx_key'])
 
     def __init__(self, *args):
         super(ZabbixAlerter, self).__init__(*args)
 
-        self.zbx_sender_host = self.rule.get("zbx_sender_host", "localhost")
-        self.zbx_sender_port = self.rule.get("zbx_sender_port", 10051)
-        self.zbx_host_from_field = self.rule.get("zbx_host_from_field", False)
-        self.zbx_host = self.rule.get("zbx_host", None)
-        self.zbx_key = self.rule.get("zbx_key", None)
-        self.timestamp_field = self.rule.get("timestamp_field", "@timestamp")
-        self.timestamp_type = self.rule.get("timestamp_type", "iso")
-        self.timestamp_strptime = self.rule.get(
-            "timestamp_strptime", "%Y-%m-%dT%H:%M:%S.%f%z"
-        )
+        self.zbx_sender_host = self.rule.get('zbx_sender_host', 'localhost')
+        self.zbx_sender_port = self.rule.get('zbx_sender_port', 10051)
+        self.zbx_host_from_field = self.rule.get('zbx_host_from_field', False)
+        self.zbx_host = self.rule.get('zbx_host', None)
+        self.zbx_key = self.rule.get('zbx_key', None)
+        self.timestamp_field = self.rule.get('timestamp_field', '@timestamp')
+        self.timestamp_type = self.rule.get('timestamp_type', 'iso')
+        self.timestamp_strptime = self.rule.get('timestamp_strptime', '%Y-%m-%dT%H:%M:%S.%f%z')
 
     # Alert is called
     def alert(self, matches):
@@ -83,57 +68,33 @@ class ZabbixAlerter(Alerter):
         # the aggregation option set
         zm = []
         for match in matches:
-            if (
-                ":" not in match[self.timestamp_field]
-                or "-" not in match[self.timestamp_field]
-            ):
+            if ':' not in match[self.timestamp_field] or '-' not in match[self.timestamp_field]:
                 ts_epoch = int(match[self.timestamp_field])
             else:
                 try:
-                    ts_epoch = int(
-                        datetime.strptime(
-                            match[self.timestamp_field], self.timestamp_strptime
-                        ).timestamp()
-                    )
+                    ts_epoch = int(datetime.strptime(match[self.timestamp_field], self.timestamp_strptime)
+                                   .timestamp())
                 except ValueError:
-                    ts_epoch = int(
-                        datetime.strptime(
-                            match[self.timestamp_field], "%Y-%m-%dT%H:%M:%S%z"
-                        ).timestamp()
-                    )
+                    ts_epoch = int(datetime.strptime(match[self.timestamp_field], '%Y-%m-%dT%H:%M:%S%z')
+                                   .timestamp())
             if self.zbx_host_from_field:
                 zbx_host = lookup_es_key(match, self.rule["zbx_host"])
             else:
                 zbx_host = self.zbx_host
-            zm.append(
-                ZabbixMetric(host=zbx_host, key=self.zbx_key, value="1", clock=ts_epoch)
-            )
+            zm.append(ZabbixMetric(host=zbx_host, key=self.zbx_key, value='1', clock=ts_epoch))
 
         try:
-            response = ZabbixSender(
-                zabbix_server=self.zbx_sender_host, zabbix_port=self.zbx_sender_port
-            ).send(zm)
+            response = ZabbixSender(zabbix_server=self.zbx_sender_host, zabbix_port=self.zbx_sender_port).send(zm)
             if response.failed:
                 if self.zbx_host_from_field and not zbx_host:
-                    elastalert_logger.warning(
-                        "Missing term '%s' or host's item '%s', alert will be discarded"
-                        % (self.zbx_host, self.zbx_key)
-                    )
+                    elastalert_logger.warning("Missing term '%s' or host's item '%s', alert will be discarded"
+                                              % (self.zbx_host, self.zbx_key))
                 else:
-                    elastalert_logger.warning(
-                        "Missing zabbix host '%s' or host's item '%s', alert will be discarded"
-                        % (zbx_host, self.zbx_key)
-                    )
+                    elastalert_logger.warning("Missing zabbix host '%s' or host's item '%s', alert will be discarded"
+                                              % (zbx_host, self.zbx_key))
             else:
-                elastalert_logger.info(
-                    "Alert sent to '%s:%s' zabbix server, '%s' zabbix host, '%s' zabbix host key"
-                    % (
-                        self.zbx_sender_host,
-                        self.zbx_sender_port,
-                        zbx_host,
-                        self.zbx_key,
-                    )
-                )
+                elastalert_logger.info("Alert sent to '%s:%s' zabbix server, '%s' zabbix host, '%s' zabbix host key"
+                                       % (self.zbx_sender_host, self.zbx_sender_port, zbx_host, self.zbx_key))
         except Exception as e:
             raise EAException("Error sending alert to Zabbix: %s" % e)
 
@@ -141,4 +102,4 @@ class ZabbixAlerter(Alerter):
     # to Elasticsearch in the field "alert_info"
     # It should return a dict of information relevant to what the alert does
     def get_info(self):
-        return {"type": "zabbix Alerter"}
+        return {'type': 'zabbix Alerter'}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -688,5 +688,6 @@ properties:
   ### Zabbix
   zbx_sender_host: {type: string}
   zbx_sender_port: {type: integer}
+  zbx_host_from_field: {type: boolean}
   zbx_host: {type: string}
   zbx_key: {type: string}

--- a/tests/alerters/zabbix_test.py
+++ b/tests/alerters/zabbix_test.py
@@ -11,146 +11,132 @@ from elastalert.util import EAException
 def test_zabbix_basic(caplog):
     caplog.set_level(logging.WARNING)
     rule = {
-        "name": "Basic Zabbix test",
-        "type": "any",
-        "alert_text_type": "alert_text_only",
-        "alert": [],
-        "alert_subject": "Test Zabbix",
-        "zbx_host": "example.com",
-        "zbx_key": "example-key",
+        'name': 'Basic Zabbix test',
+        'type': 'any',
+        'alert_text_type': 'alert_text_only',
+        'alert': [],
+        'alert_subject': 'Test Zabbix',
+        'zbx_host': 'example.com',
+        'zbx_key': 'example-key'
     }
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = ZabbixAlerter(rule)
-    match = {"@timestamp": "2021-01-01T00:00:00Z", "somefield": "foobarbaz"}
-    with mock.patch("pyzabbix.ZabbixSender.send") as mock_zbx_send:
+    match = {
+        '@timestamp': '2021-01-01T00:00:00Z',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('pyzabbix.ZabbixSender.send') as mock_zbx_send:
         alert.alert([match])
 
         zabbix_metrics = {
             "host": "example.com",
             "key": "example-key",
             "value": "1",
-            "clock": 1609459200,
+            "clock": 1609459200
         }
         alerter_args = mock_zbx_send.call_args.args
         assert vars(alerter_args[0][0]) == zabbix_metrics
         log_messeage = "Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded"
-        assert ("elastalert", logging.WARNING, log_messeage) == caplog.record_tuples[0]
+        assert ('elastalert', logging.WARNING, log_messeage) == caplog.record_tuples[0]
 
 
-@pytest.mark.parametrize(
-    "zbx_host_from_field, zbx_host, zbx_key, log_messeage",
-    [
-        (
-            True,
-            "hostname",
-            "example-key",
-            "Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded",
-        ),
-        (
-            True,
-            "unavailable_field",
-            "example-key",
-            "Missing term 'unavailable_field' or host's item 'example-key', alert will be discarded",
-        ),
-        (
-            False,
-            "hostname",
-            "example-key",
-            "Missing zabbix host 'hostname' or host's item 'example-key', alert will be discarded",
-        ),
-        (
-            False,
-            "unavailable_field",
-            "example-key",
-            "Missing zabbix host 'unavailable_field' or host's item 'example-key', alert will be discarded",
-        ),
-    ],
-)
+@pytest.mark.parametrize('zbx_host_from_field, zbx_host, zbx_key, log_messeage', [
+        (True, 'hostname', 'example-key',
+         "Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded"),
+        (True, 'unavailable_field', 'example-key',
+         "Missing term 'unavailable_field' or host's item 'example-key', alert will be discarded"),
+        (False, 'hostname', 'example-key',
+         "Missing zabbix host 'hostname' or host's item 'example-key', alert will be discarded"),
+        (False, 'unavailable_field', 'example-key',
+         "Missing zabbix host 'unavailable_field' or host's item 'example-key', alert will be discarded")
+])
 def test_zabbix_enhanced(caplog, zbx_host_from_field, zbx_host, zbx_key, log_messeage):
     caplog.set_level(logging.WARNING)
     rule = {
-        "name": "Enhanced Zabbix test",
-        "type": "any",
-        "alert_text_type": "alert_text_only",
-        "alert": [],
-        "alert_subject": "Test Zabbix",
-        "zbx_host_from_field": zbx_host_from_field,
-        "zbx_host": zbx_host,
-        "zbx_key": zbx_key,
+        'name': 'Enhanced Zabbix test',
+        'type': 'any',
+        'alert_text_type': 'alert_text_only',
+        'alert': [],
+        'alert_subject': 'Test Zabbix',
+        'zbx_host_from_field': zbx_host_from_field,
+        'zbx_host': zbx_host,
+        'zbx_key': zbx_key
     }
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = ZabbixAlerter(rule)
     match = {
-        "@timestamp": "2021-01-01T00:00:00Z",
-        "somefield": "foobarbaz",
-        "hostname": "example.com",
+        '@timestamp': '2021-01-01T00:00:00Z',
+        'somefield': 'foobarbaz',
+        'hostname': 'example.com'
     }
-    with mock.patch("pyzabbix.ZabbixSender.send") as mock_zbx_send:
+    with mock.patch('pyzabbix.ZabbixSender.send') as mock_zbx_send:
         alert.alert([match])
 
         hosts = {
-            (True, "hostname"): "example.com",
-            (True, "unavailable_field"): "None",
-            (False, "hostname"): "hostname",
-            (False, "unavailable_field"): "unavailable_field",
+            (True, 'hostname'): 'example.com',
+            (True, 'unavailable_field'): 'None',
+            (False, 'hostname'): 'hostname',
+            (False, 'unavailable_field'): 'unavailable_field'
         }
 
         zabbix_metrics = {
-            "host": hosts[(zbx_host_from_field, zbx_host)],
-            "key": "example-key",
-            "value": "1",
-            "clock": 1609459200,
+            'host': hosts[(zbx_host_from_field, zbx_host)],
+            'key': 'example-key',
+            'value': '1',
+            'clock': 1609459200
         }
         alerter_args = mock_zbx_send.call_args.args
         assert vars(alerter_args[0][0]) == zabbix_metrics
-        assert ("elastalert", logging.WARNING, log_messeage) == caplog.record_tuples[0]
+        assert ('elastalert', logging.WARNING, log_messeage) == caplog.record_tuples[0]
 
 
 def test_zabbix_getinfo():
     rule = {
-        "name": "Basic Zabbix test",
-        "type": "any",
-        "alert_text_type": "alert_text_only",
-        "alert": [],
-        "alert_subject": "Test Zabbix",
-        "zbx_host": "example.com",
-        "zbx_key": "example-key",
+        'name': 'Basic Zabbix test',
+        'type': 'any',
+        'alert_text_type': 'alert_text_only',
+        'alert': [],
+        'alert_subject': 'Test Zabbix',
+        'zbx_host': 'example.com',
+        'zbx_key': 'example-key'
     }
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = ZabbixAlerter(rule)
 
-    expected_data = {"type": "zabbix Alerter"}
+    expected_data = {
+        'type': 'zabbix Alerter'
+    }
     actual_data = alert.get_info()
     assert expected_data == actual_data
 
 
-@pytest.mark.parametrize(
-    "zbx_host, zbx_key, expected_data",
-    [
-        ("", "", "Missing required option(s): zbx_host, zbx_key"),
-        ("example.com", "", "Missing required option(s): zbx_host, zbx_key"),
-        ("", "example-key", "Missing required option(s): zbx_host, zbx_key"),
-        ("example.com", "example-key", {"type": "zabbix Alerter"}),
-    ],
-)
+@pytest.mark.parametrize('zbx_host, zbx_key, expected_data', [
+    ('',            '',            'Missing required option(s): zbx_host, zbx_key'),
+    ('example.com', '',            'Missing required option(s): zbx_host, zbx_key'),
+    ('',            'example-key', 'Missing required option(s): zbx_host, zbx_key'),
+    ('example.com', 'example-key',
+        {
+            'type': 'zabbix Alerter'
+        })
+])
 def test_zabbix_required_error(zbx_host, zbx_key, expected_data):
     try:
         rule = {
-            "name": "Basic Zabbix test",
-            "type": "any",
-            "alert_text_type": "alert_text_only",
-            "alert": [],
-            "alert_subject": "Test Zabbix",
+            'name': 'Basic Zabbix test',
+            'type': 'any',
+            'alert_text_type': 'alert_text_only',
+            'alert': [],
+            'alert_subject': 'Test Zabbix'
         }
 
         if zbx_host:
-            rule["zbx_host"] = zbx_host
+            rule['zbx_host'] = zbx_host
 
         if zbx_key:
-            rule["zbx_key"] = zbx_key
+            rule['zbx_key'] = zbx_key
 
         rules_loader = FileRulesLoader({})
         rules_loader.load_modules(rule)
@@ -165,21 +151,21 @@ def test_zabbix_required_error(zbx_host, zbx_key, expected_data):
 def test_zabbix_ea_exception():
     with pytest.raises(EAException) as ea:
         rule = {
-            "name": "Basic Zabbix test",
-            "type": "any",
-            "alert_text_type": "alert_text_only",
-            "alert": [],
-            "alert_subject": "Test Zabbix",
-            "zbx_host": "example.com",
-            "zbx_key": "example-key",
+            'name': 'Basic Zabbix test',
+            'type': 'any',
+            'alert_text_type': 'alert_text_only',
+            'alert': [],
+            'alert_subject': 'Test Zabbix',
+            'zbx_host': 'example.com',
+            'zbx_key': 'example-key'
         }
         match = {
-            "@timestamp": "2021-01-01T00:00:00Z",
-            "somefield": "foobarbaz",
+            '@timestamp': '2021-01-01T00:00:00Z',
+            'somefield': 'foobarbaz'
         }
         rules_loader = FileRulesLoader({})
         rules_loader.load_modules(rule)
         alert = ZabbixAlerter(rule)
         alert.alert([match])
 
-    assert "Error sending alert to Zabbix: " in str(ea)
+    assert 'Error sending alert to Zabbix: ' in str(ea)

--- a/tests/alerters/zabbix_test.py
+++ b/tests/alerters/zabbix_test.py
@@ -11,81 +11,146 @@ from elastalert.util import EAException
 def test_zabbix_basic(caplog):
     caplog.set_level(logging.WARNING)
     rule = {
-        'name': 'Basic Zabbix test',
-        'type': 'any',
-        'alert_text_type': 'alert_text_only',
-        'alert': [],
-        'alert_subject': 'Test Zabbix',
-        'zbx_host': 'example.com',
-        'zbx_key': 'example-key'
+        "name": "Basic Zabbix test",
+        "type": "any",
+        "alert_text_type": "alert_text_only",
+        "alert": [],
+        "alert_subject": "Test Zabbix",
+        "zbx_host": "example.com",
+        "zbx_key": "example-key",
     }
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = ZabbixAlerter(rule)
-    match = {
-        '@timestamp': '2021-01-01T00:00:00Z',
-        'somefield': 'foobarbaz'
-    }
-    with mock.patch('pyzabbix.ZabbixSender.send') as mock_zbx_send:
+    match = {"@timestamp": "2021-01-01T00:00:00Z", "somefield": "foobarbaz"}
+    with mock.patch("pyzabbix.ZabbixSender.send") as mock_zbx_send:
         alert.alert([match])
 
         zabbix_metrics = {
             "host": "example.com",
             "key": "example-key",
             "value": "1",
-            "clock": 1609459200
+            "clock": 1609459200,
         }
         alerter_args = mock_zbx_send.call_args.args
         assert vars(alerter_args[0][0]) == zabbix_metrics
         log_messeage = "Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded"
-        assert ('elastalert', logging.WARNING, log_messeage) == caplog.record_tuples[0]
+        assert ("elastalert", logging.WARNING, log_messeage) == caplog.record_tuples[0]
+
+
+@pytest.mark.parametrize(
+    "zbx_host_from_field, zbx_host, zbx_key, log_messeage",
+    [
+        (
+            True,
+            "hostname",
+            "example-key",
+            "Missing zabbix host 'example.com' or host's item 'example-key', alert will be discarded",
+        ),
+        (
+            True,
+            "unavailable_field",
+            "example-key",
+            "Missing term 'unavailable_field' or host's item 'example-key', alert will be discarded",
+        ),
+        (
+            False,
+            "hostname",
+            "example-key",
+            "Missing zabbix host 'hostname' or host's item 'example-key', alert will be discarded",
+        ),
+        (
+            False,
+            "unavailable_field",
+            "example-key",
+            "Missing zabbix host 'unavailable_field' or host's item 'example-key', alert will be discarded",
+        ),
+    ],
+)
+def test_zabbix_enhanced(caplog, zbx_host_from_field, zbx_host, zbx_key, log_messeage):
+    caplog.set_level(logging.WARNING)
+    rule = {
+        "name": "Enhanced Zabbix test",
+        "type": "any",
+        "alert_text_type": "alert_text_only",
+        "alert": [],
+        "alert_subject": "Test Zabbix",
+        "zbx_host_from_field": zbx_host_from_field,
+        "zbx_host": zbx_host,
+        "zbx_key": zbx_key,
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = ZabbixAlerter(rule)
+    match = {
+        "@timestamp": "2021-01-01T00:00:00Z",
+        "somefield": "foobarbaz",
+        "hostname": "example.com",
+    }
+    with mock.patch("pyzabbix.ZabbixSender.send") as mock_zbx_send:
+        alert.alert([match])
+
+        hosts = {
+            (True, "hostname"): "example.com",
+            (True, "unavailable_field"): "None",
+            (False, "hostname"): "hostname",
+            (False, "unavailable_field"): "unavailable_field",
+        }
+
+        zabbix_metrics = {
+            "host": hosts[(zbx_host_from_field, zbx_host)],
+            "key": "example-key",
+            "value": "1",
+            "clock": 1609459200,
+        }
+        alerter_args = mock_zbx_send.call_args.args
+        assert vars(alerter_args[0][0]) == zabbix_metrics
+        assert ("elastalert", logging.WARNING, log_messeage) == caplog.record_tuples[0]
 
 
 def test_zabbix_getinfo():
     rule = {
-        'name': 'Basic Zabbix test',
-        'type': 'any',
-        'alert_text_type': 'alert_text_only',
-        'alert': [],
-        'alert_subject': 'Test Zabbix',
-        'zbx_host': 'example.com',
-        'zbx_key': 'example-key'
+        "name": "Basic Zabbix test",
+        "type": "any",
+        "alert_text_type": "alert_text_only",
+        "alert": [],
+        "alert_subject": "Test Zabbix",
+        "zbx_host": "example.com",
+        "zbx_key": "example-key",
     }
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = ZabbixAlerter(rule)
 
-    expected_data = {
-        'type': 'zabbix Alerter'
-    }
+    expected_data = {"type": "zabbix Alerter"}
     actual_data = alert.get_info()
     assert expected_data == actual_data
 
 
-@pytest.mark.parametrize('zbx_host, zbx_key, expected_data', [
-    ('',            '',            'Missing required option(s): zbx_host, zbx_key'),
-    ('example.com', '',            'Missing required option(s): zbx_host, zbx_key'),
-    ('',            'example-key', 'Missing required option(s): zbx_host, zbx_key'),
-    ('example.com', 'example-key',
-        {
-            'type': 'zabbix Alerter'
-        })
-])
+@pytest.mark.parametrize(
+    "zbx_host, zbx_key, expected_data",
+    [
+        ("", "", "Missing required option(s): zbx_host, zbx_key"),
+        ("example.com", "", "Missing required option(s): zbx_host, zbx_key"),
+        ("", "example-key", "Missing required option(s): zbx_host, zbx_key"),
+        ("example.com", "example-key", {"type": "zabbix Alerter"}),
+    ],
+)
 def test_zabbix_required_error(zbx_host, zbx_key, expected_data):
     try:
         rule = {
-            'name': 'Basic Zabbix test',
-            'type': 'any',
-            'alert_text_type': 'alert_text_only',
-            'alert': [],
-            'alert_subject': 'Test Zabbix'
+            "name": "Basic Zabbix test",
+            "type": "any",
+            "alert_text_type": "alert_text_only",
+            "alert": [],
+            "alert_subject": "Test Zabbix",
         }
 
         if zbx_host:
-            rule['zbx_host'] = zbx_host
+            rule["zbx_host"] = zbx_host
 
         if zbx_key:
-            rule['zbx_key'] = zbx_key
+            rule["zbx_key"] = zbx_key
 
         rules_loader = FileRulesLoader({})
         rules_loader.load_modules(rule)
@@ -100,21 +165,21 @@ def test_zabbix_required_error(zbx_host, zbx_key, expected_data):
 def test_zabbix_ea_exception():
     with pytest.raises(EAException) as ea:
         rule = {
-            'name': 'Basic Zabbix test',
-            'type': 'any',
-            'alert_text_type': 'alert_text_only',
-            'alert': [],
-            'alert_subject': 'Test Zabbix',
-            'zbx_host': 'example.com',
-            'zbx_key': 'example-key'
+            "name": "Basic Zabbix test",
+            "type": "any",
+            "alert_text_type": "alert_text_only",
+            "alert": [],
+            "alert_subject": "Test Zabbix",
+            "zbx_host": "example.com",
+            "zbx_key": "example-key",
         }
         match = {
-            '@timestamp': '2021-01-01T00:00:00Z',
-            'somefield': 'foobarbaz'
+            "@timestamp": "2021-01-01T00:00:00Z",
+            "somefield": "foobarbaz",
         }
         rules_loader = FileRulesLoader({})
         rules_loader.load_modules(rule)
         alert = ZabbixAlerter(rule)
         alert.alert([match])
 
-    assert 'Error sending alert to Zabbix: ' in str(ea)
+    assert "Error sending alert to Zabbix: " in str(ea)


### PR DESCRIPTION
## Description


Add the ability to specify `zbx_host` from available elasticsearch field.

By default, zabbix alerter send "1" to single host with specified `zbx_host` hostname. For a large number of hosts in zabbix, it would be convenient to specify `zbx_host` value from available elasticsearch field.

More details - #812 


## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
