### PR TITLE
Add the possibility to add tags, tlp, and message in TheHive observables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add support for Kibana 8.2 for Kibana Discover, Upgrade Pytest 7.1.1 to 7.1.2, Upgrade pylint 2.13.5 to 2.13.8, Upgrade Jinja2 3.1.1 to 3.1.2 - [#840](https://github.com/jertel/elastalert2/pull/840) - @nsano-rururu
 - Add the possibility to use rule and match fields in the description of TheHive alerts - [#855](https://github.com/jertel/elastalert2/pull/855) - @luffynextgen
 - Fix missing colon on schema.yml and add unit test on it - [#866](https://github.com/jertel/elastalert2/pull/866) - @Isekai-Seikatsu
-- Add the possibility to use tags, message and tlp level in TheHive observables [#873][https://github.com/jertel/elastalert2/pull/873]
+- Add the possibility to use tags, message and tlp level in TheHive observables [#873][https://github.com/jertel/elastalert2/pull/873] - @luffynextgen
 
 # 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add support for Kibana 8.2 for Kibana Discover, Upgrade Pytest 7.1.1 to 7.1.2, Upgrade pylint 2.13.5 to 2.13.8, Upgrade Jinja2 3.1.1 to 3.1.2 - [#840](https://github.com/jertel/elastalert2/pull/840) - @nsano-rururu
 - Add the possibility to use rule and match fields in the description of TheHive alerts - [#855](https://github.com/jertel/elastalert2/pull/855) - @luffynextgen
 - Fix missing colon on schema.yml and add unit test on it - [#866](https://github.com/jertel/elastalert2/pull/866) - @Isekai-Seikatsu
+- Add the possibility to use tags, message and tlp level in TheHive observables [#873][https://github.com/jertel/elastalert2/pull/873]
 
 # 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add support for Kibana 8.2 for Kibana Discover, Upgrade Pytest 7.1.1 to 7.1.2, Upgrade pylint 2.13.5 to 2.13.8, Upgrade Jinja2 3.1.1 to 3.1.2 - [#840](https://github.com/jertel/elastalert2/pull/840) - @nsano-rururu
 - Add the possibility to use rule and match fields in the description of TheHive alerts - [#855](https://github.com/jertel/elastalert2/pull/855) - @luffynextgen
 - Fix missing colon on schema.yml and add unit test on it - [#866](https://github.com/jertel/elastalert2/pull/866) - @Isekai-Seikatsu
-- Add the possibility to use tags, message and tlp level in TheHive observables [#873][https://github.com/jertel/elastalert2/pull/873] - @luffynextgen
+- Add the possibility to use tags, message and tlp level in TheHive observables [#873](https://github.com/jertel/elastalert2/pull/873) - @luffynextgen
 
 # 2.5.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3225,8 +3225,9 @@ using the first matched record, before checking the rule. If neither matches, th
 will be used directly.
 
 ``hive_observable_data_mapping``: If needed, matched data fields can be mapped to TheHive
-observable types using the same syntax as ``tags``, described above. The algorithm used to populate
-the observable value is also the same, including the behaviour for aggregated alerts.
+observable types using the same syntax as ``customFields``, described above. The algorithm used to populate
+the observable value is similar to the one used to populate the ``tags``, including the behaviour for aggregated alerts.
+The tlp, message and tags fields are optionnal for each observable and will be field with a default value if not used.
 
 ``hive_proxies``: Proxy configuration.
 
@@ -3265,7 +3266,12 @@ Example usage::
 
     hive_observable_data_mapping:
       - domain: agent.hostname
+        tlp: 1
+        tags: ['hostname', agent']
+        message: 'agent hostname'
       - domain: response.domain
+        tlp: 2
+        tags: ['domain']
       - ip: client.ip
 
 Twilio

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3227,7 +3227,7 @@ will be used directly.
 ``hive_observable_data_mapping``: If needed, matched data fields can be mapped to TheHive
 observable types using the same syntax as ``customFields``, described above. The algorithm used to populate
 the observable value is similar to the one used to populate the ``tags``, including the behaviour for aggregated alerts.
-The tlp, message and tags fields are optionnal for each observable and will be field with a default value if not used.
+The tlp, message, and tags fields are optional for each observable. If not specified, the tlp field is given a default value of 2.
 
 ``hive_proxies``: Proxy configuration.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3267,11 +3267,11 @@ Example usage::
     hive_observable_data_mapping:
       - domain: agent.hostname
         tlp: 1
-        tags: ['hostname', agent']
+        tags: ['tag1', 'tag2']
         message: 'agent hostname'
       - domain: response.domain
         tlp: 2
-        tags: ['domain']
+        tags: ['tag3']
       - ip: client.ip
 
 Twilio

--- a/elastalert/alerters/thehive.py
+++ b/elastalert/alerters/thehive.py
@@ -34,15 +34,22 @@ class HiveAlerter(Alerter):
         artifacts = []
         for mapping in self.rule.get('hive_observable_data_mapping', []):
             for observable_type, mapping_key in mapping.items():
-                data = str(self.lookup_field(match, mapping_key, ''))
-                if len(data) != 0:
-                    artifact = {'tlp': 2,
-                                'tags': [],
-                                'message': None,
-                                'dataType': observable_type,
-                                'data': data}
-                    artifacts.append(artifact)
-
+                if (observable_type != "tlp" and observable_type != "message" and observable_type != "tags"):
+                    data = str(self.lookup_field(match, mapping_key, ''))
+                    if len(data) != 0:
+                        artifact = {'tlp': 2,
+                                    'tags': [],
+                                    'message': None,
+                                    'dataType': observable_type,
+                                    'data': data}
+                        if mapping.get('tlp') is not None:
+                            artifact['tlp'] = mapping['tlp']
+                        if mapping.get('message') is not None:
+                            artifact['message'] = mapping['message']
+                        if mapping.get('tags') is not None:
+                            artifact['tags'] = mapping['tags']
+                        artifacts.append(artifact)
+                break
         return artifacts
 
     def load_custom_fields(self, custom_fields_raw: list, match: dict):

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -163,7 +163,7 @@ def test_thehive_getinfo(hive_host, expect):
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': hive_host,
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}], 
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -474,6 +474,7 @@ def test_load_description_missing_value_default():
     expected = "Unit test from host:<MISSING VALUE> to 127.0.0.1"
     assert actual == expected
 
+
 def test_load_observable_artifacts():
     rule = {'alert': [],
             'alert_text': '',
@@ -495,7 +496,11 @@ def test_load_observable_artifacts():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags'}, {'autonomous-system': 'test.as_number', 'tlp': 2, 'tags': ['autonomous']}, {'username': 'user.name', 'tlp': 1}, {'filename': 'process.name'}, {'ip': 'destination.ip'}],
+            'hive_observable_data_mapping': [
+                {'ip': 'test.ip', 'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags'},
+                {'autonomous-system': 'test.as_number', 'tlp': 2, 'tags': ['autonomous']}, 
+                {'username': 'user.name', 'tlp': 1}, {'filename': 'process.name'}, {'ip': 'destination.ip'}
+                ],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -517,5 +522,10 @@ def test_load_observable_artifacts():
         "@timestamp": "2021-05-09T14:43:30",
     }
     actual = alert.load_observable_artifacts(match)
-    expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 2, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
+    expected = [
+        {'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'},
+        {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'},
+        {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'},
+        {'tlp': 2, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}
+    ]
     assert actual == expected

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -163,7 +163,7 @@ def test_thehive_getinfo(hive_host, expect):
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': hive_host,
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip'}], 
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -498,7 +498,7 @@ def test_load_observable_artifacts():
                                 'hive_port': 9000},
             'hive_observable_data_mapping': [
                 {'ip': 'test.ip', 'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags'},
-                {'autonomous-system': 'test.as_number', 'tlp': 2, 'tags': ['autonomous']}, 
+                {'autonomous-system': 'test.as_number', 'tlp': 2, 'tags': ['autonomous']},
                 {'username': 'user.name', 'tlp': 1}, {'filename': 'process.name'}, {'ip': 'destination.ip'}
                 ],
             'name': 'test-thehive',
@@ -524,7 +524,7 @@ def test_load_observable_artifacts():
     actual = alert.load_observable_artifacts(match)
     expected = [
         {'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'},
-        {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'},
+        {'tlp': 2, 'tags': ['autonomous'], 'message': None, 'dataType': 'autonomous-system', 'data': '1234'},
         {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'},
         {'tlp': 2, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}
     ]

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -517,5 +517,5 @@ def test_load_observable_artifacts():
         "@timestamp": "2021-05-09T14:43:30",
     }
     actual = alert.load_observable_artifacts(match)
-    expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': 1234}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
+    expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
     assert actual == expected

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -517,5 +517,5 @@ def test_load_observable_artifacts():
         "@timestamp": "2021-05-09T14:43:30",
     }
     actual = alert.load_observable_artifacts(match)
-    expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
+    expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': '1234'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 2, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
     assert actual == expected

--- a/tests/alerters/thehive_test.py
+++ b/tests/alerters/thehive_test.py
@@ -29,7 +29,7 @@ def test_thehive_alerter(caplog):
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -194,7 +194,7 @@ def test_thehive_alerter2():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -291,7 +291,7 @@ def test_load_tags(tags, expect):
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -324,7 +324,7 @@ def test_load_description_default():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -366,7 +366,7 @@ def test_load_description_no_args():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -411,7 +411,7 @@ def test_load_description_args():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -454,7 +454,7 @@ def test_load_description_missing_value_default():
             'hive_connection': {'hive_apikey': '',
                                 'hive_host': 'https://localhost',
                                 'hive_port': 9000},
-            'hive_observable_data_mapping': [{'ip': 'test.ip', 'autonomous-system': 'test.as_number'}],
+            'hive_observable_data_mapping': [{'ip': 'test.ip'}, {'autonomous-system': 'test.as_number'}],
             'name': 'test-thehive',
             'tags': ['a', 'b'],
             'type': 'any'}
@@ -516,6 +516,6 @@ def test_load_observable_artifacts():
         },
         "@timestamp": "2021-05-09T14:43:30",
     }
-    actual = alert.load_description(match)
+    actual = alert.load_observable_artifacts(match)
     expected = [{'tlp': 1, 'tags': ['ip', 'test'], 'message': 'test tags', 'dataType': 'ip', 'data': '127.0.0.1'}, {'tlp': 2, 'tags': ['autonomous'], 'message': None,'dataType': 'autonomous-system', 'data': 1234}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'username', 'data': 'toto'}, {'tlp': 1, 'tags': [], 'message': None, 'dataType': 'filename', 'data': 'mstc.exe'}]
     assert actual == expected


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

I added the possibility to add tags, modify tlp level and add messages on TheHive observables.
There is no breaking change.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->

I do not have a docker environment so I ran the test to develop the feature on my test environment