### PR TITLE
Fix HTTP POST 2, now json-escaping all strings replaced by the jinja2 template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.TBD.TBD
 
 ## Breaking changes
-- When using HTTP POST 2, it is no longer necessary to pre-escaped strings from events in elastic search which are replaced by the jinja2 template.
+- When using HTTP POST 2, it is no longer necessary to pre-escape strings (should they contain control chars) from events in elastic search which are replaced by the jinja2 template.
 
 ## New features
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.TBD.TBD
 
 ## Breaking changes
-- None
+- When using HTTP POST 2, it is no longer necessary to pre-escaped strings from events in elastic search which are replaced by the jinja2 template.
 
 ## New features
 - None
@@ -9,6 +9,7 @@
 ## Other changes
 - Upgrade pylint 2.13.8 to 2.14.3, Upgrade sphinx 4.5.0 to 5.0.2 - [#891](https://github.com/jertel/elastalert2/pull/891) - @nsano-rururu
 - Add support for Kibana 8.3 for Kibana Discover - [#897](https://github.com/jertel/elastalert2/pull/897) - @nsano-rururu
+- Fix internal json decode error in HTTP POST 2 if values from ES event contain control chars (e.g. newline) and are used in the jinja2 template - [#898](https://github.com/jertel/elastalert2/pull/898) - @ddurham2
 
 # 2.5.1
 

--- a/elastalert/alerters/httppost2.py
+++ b/elastalert/alerters/httppost2.py
@@ -7,6 +7,19 @@ from requests import RequestException
 from elastalert.alerts import Alerter, DateTimeEncoder
 from elastalert.util import lookup_es_key, EAException, elastalert_logger
 
+def _json_escape(s):
+    return json.encoder.encode_basestring(s)[1:-1]
+
+def _escape_all_values(x):
+    """recursively rebuilds, and escapes all strings for json, the given dict/list"""
+    if isinstance(x, dict):
+        x = { k:_escape_all_values(v) for k, v in x.items() }
+    elif isinstance(x, list):
+        x = [ _escape_all_values(v) for v in x ]
+    elif isinstance(x, str):
+        x = _json_escape(x)
+    return x
+
 
 class HTTPPost2Alerter(Alerter):
     """ Requested elasticsearch indices are sent by HTTP POST. Encoded with JSON. """
@@ -30,6 +43,7 @@ class HTTPPost2Alerter(Alerter):
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
         for match in matches:
+            match = _escape_all_values(match)
             payload = match if self.post_all_values else {}
             payload_template = Template(json.dumps(self.post_payload))
             payload_res = json.loads(payload_template.render(**match))

--- a/elastalert/alerters/httppost2.py
+++ b/elastalert/alerters/httppost2.py
@@ -43,10 +43,10 @@ class HTTPPost2Alerter(Alerter):
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
         for match in matches:
-            match = _escape_all_values(match)
+            match_js_esc = _escape_all_values(match)
             payload = match if self.post_all_values else {}
             payload_template = Template(json.dumps(self.post_payload))
-            payload_res = json.loads(payload_template.render(**match))
+            payload_res = json.loads(payload_template.render(**match_js_esc))
             payload = {**payload, **payload_res}
 
             for post_key, es_key in list(self.post_raw_fields.items()):
@@ -60,7 +60,7 @@ class HTTPPost2Alerter(Alerter):
                 requests.packages.urllib3.disable_warnings()
 
             header_template = Template(json.dumps(self.post_http_headers))
-            header_res = json.loads(header_template.render(**match))
+            header_res = json.loads(header_template.render(**match_js_esc))
             headers = {
                 "Content-Type": "application/json",
                 "Accept": "application/json;charset=utf-8",

--- a/tests/alerters/httppost2_test.py
+++ b/tests/alerters/httppost2_test.py
@@ -162,12 +162,12 @@ def test_http_alerter_with_payload_args_keys(caplog):
     alert = HTTPPost2Alerter(rule)
     match = {
         '@timestamp': '2017-01-01T00:00:00',
-        'some_field': 'toto'
+        'some_field': 'to\tto'  # include some specially handled control char
     }
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'args_toto': 'tata',
+        'args_to\tto': 'tata',
     }
     mock_post_request.assert_called_once_with(
         rule['http_post2_url'],
@@ -294,13 +294,13 @@ def test_http_alerter_with_payload_args_value(caplog):
     alert = HTTPPost2Alerter(rule)
     match = {
         '@timestamp': '2017-01-01T00:00:00',
-        'some_field': 'foobarbaz'
+        'some_field': 'foo\tbar\nbaz'  # include some specially handled control chars
     }
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
         'posted_name': 'toto',
-        'args_name': 'foobarbaz',
+        'args_name': 'foo\tbar\nbaz',
     }
     mock_post_request.assert_called_once_with(
         rule['http_post2_url'],
@@ -398,14 +398,14 @@ def test_http_alerter_with_header_args_value(caplog):
     alert = HTTPPost2Alerter(rule)
     match = {
         '@timestamp': '2017-01-01T00:00:00',
-        'titi': 'foobarbaz'
+        'titi': 'foo\tbarbaz'  # include some specially handled control chars
     }
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json;charset=utf-8',
-        'header_name': 'foobarbaz'
+        'header_name': 'foo\tbarbaz'
     }
     mock_post_request.assert_called_once_with(
         rule['http_post2_url'],


### PR DESCRIPTION
## Description
For HTTP POST 2, now json-escaping all strings replaced by the jinja2 template in the json which otherwise leads to a syntax error in the json which will not deserialize properly.  See #896 for more details on what was happening.

Will it break anything?  Before the fix, if a matched event's value contained a newline (or any other control chars that json escapes) and if that value was included in the jinja2 template, the json of the post body could not be generated, because it would internally attempt to deserialize a now-invalid json string.

If anyone else in the field had encountered this problem, they may have worked around it by including already-escaped values before sending into elastic search (which would affect any other downstream processors of the event, needing to know to undo that hack to the value).  This fix should address the internal-processing problem in elastalert once and for all, but users would need to read the changelog and stop doing their work-around as they upgrade.

## Checklist

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [X] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

No changes needed to docs necessary.