### PR TITLE
Add telegram parse_mode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- None
+- [Telegram] Added new telegram_parse_mode setting to switch between markdown and html body formats. - [#924](https://github.com/jertel/elastalert2/pull/924) - @polshe-v
 
 ## Other changes
 - None

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3123,7 +3123,7 @@ Optional:
 
 ``telegram_proxy_pass``: The Telegram proxy auth password.
 
-``telegram_parse_mode``: The Telegram parsing mode for style formatting text. Possible values are ``markdown``, ``markdownV2``, ``html``.
+``telegram_parse_mode``: The Telegram parsing mode, which determines the format of the alert text body. Possible values are ``markdown``, ``markdownV2``, ``html``. Defaults to ``markdown``.
 
 Example usage::
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3123,6 +3123,8 @@ Optional:
 
 ``telegram_proxy_pass``: The Telegram proxy auth password.
 
+``telegram_parse_mode``: The Telegram parsing mode for style formatting text. Possible values are ``markdown``, ``markdownV2``, ``html``.
+
 Example usage::
 
     alert:

--- a/elastalert/alerters/telegram.py
+++ b/elastalert/alerters/telegram.py
@@ -22,9 +22,14 @@ class TelegramAlerter(Alerter):
         self.telegram_proxy = self.rule.get('telegram_proxy', None)
         self.telegram_proxy_login = self.rule.get('telegram_proxy_login', None)
         self.telegram_proxy_password = self.rule.get('telegram_proxy_pass', None)
+        self.telegram_parse_mode = self.rule.get('telegram_parse_mode', 'markdown')
 
     def alert(self, matches):
-        body = '⚠ *%s* ⚠ ```\n' % (self.create_title(matches))
+        if self.telegram_parse_mode != 'html':
+            body = '⚠ *%s* ⚠ ```\n' % (self.create_title(matches))
+        else:
+            body = '⚠ %s ⚠ \n' % (self.create_title(matches))
+
         for match in matches:
             body += str(BasicMatchString(self.rule, match))
             # Separate text of aggregated alerts with dashes
@@ -32,7 +37,9 @@ class TelegramAlerter(Alerter):
                 body += '\n----------------------------------------\n'
         if len(body) > 4095:
             body = body[0:4000] + "\n⚠ *message was cropped according to telegram limits!* ⚠"
-        body += ' ```'
+
+        if self.telegram_parse_mode != 'html':
+            body += ' ```'
 
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided
@@ -41,7 +48,7 @@ class TelegramAlerter(Alerter):
         payload = {
             'chat_id': self.telegram_room_id,
             'text': body,
-            'parse_mode': 'markdown',
+            'parse_mode': self.telegram_parse_mode,
             'disable_web_page_preview': True
         }
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -665,6 +665,7 @@ properties:
   telegram_proxy: {type: string}
   telegram_proxy_login: {type: string}
   telegram_proxy_pass: {type: string}
+  telegram_parse_mode: {type: string, enum: ['markdown', 'markdownV2', 'html']}
 
   ### Tencent SMS
   tencent_sms_secret_id: {type: string}

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -82,8 +82,8 @@ def test_import_rules():
 def test_import_import():
     rules_loader = FileRulesLoader(test_config)
     import_rule = copy.deepcopy(test_rule)
-    del(import_rule['es_host'])
-    del(import_rule['es_port'])
+    del import_rule['es_host']
+    del import_rule['es_port']
     import_rule['import'] = 'importme.ymlt'
     import_me = {
         'es_host': 'imported_host',
@@ -109,8 +109,8 @@ def test_import_import():
 def test_import_absolute_import():
     rules_loader = FileRulesLoader(test_config)
     import_rule = copy.deepcopy(test_rule)
-    del(import_rule['es_host'])
-    del(import_rule['es_port'])
+    del import_rule['es_host']
+    del import_rule['es_port']
     import_rule['import'] = '/importme.ymlt'
     import_me = {
         'es_host': 'imported_host',
@@ -135,8 +135,8 @@ def test_import_filter():
 
     rules_loader = FileRulesLoader(test_config)
     import_rule = copy.deepcopy(test_rule)
-    del(import_rule['es_host'])
-    del(import_rule['es_port'])
+    del import_rule['es_host']
+    del import_rule['es_port']
     import_rule['import'] = 'importme.ymlt'
     import_me = {
         'es_host': 'imported_host',


### PR DESCRIPTION
## Description

Added more parsing modes for Telegram and made separate option for setting parse_mode in alert rule. In order to make alert_text look pretty in all modes I added conditional alert_text formatting for markdown and html.

## Checklist

- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [X] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [X] I have updated the [documentation](https://elastalert2.readthedocs.io).

## Comments

There was a problem running `make test-docker`:
```
py310 run-test: commands[1] | flake8 --config ../setup.cfg .
./loaders_test.py:85:8: E275 missing whitespace after keyword
./loaders_test.py:86:8: E275 missing whitespace after keyword
./loaders_test.py:112:8: E275 missing whitespace after keyword
./loaders_test.py:113:8: E275 missing whitespace after keyword
./loaders_test.py:138:8: E275 missing whitespace after keyword
./loaders_test.py:139:8: E275 missing whitespace after keyword
ERROR: InvocationError for command /home/elastalert/tests/.tox/py310/bin/flake8 --config ../setup.cfg . (exited with code 1)
```

I added whitespace after `del` in these strings and all tests worked fine, all passed.