### PR TITLE
Pin exotel dependency to 0.1.5 due to security issue in 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ## New features
 - [Telegram] Added new telegram_parse_mode setting to switch between markdown and html body formats. - [#924](https://github.com/jertel/elastalert2/pull/924) - @polshe-v
 
+## Security
+
+- Pin package version of `exotel` to `0.1.5` - [#931](https://github.com/jertel/elastalert2/pull/931)
+
 ## Other changes
 - None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cffi>=1.15.0
 croniter>=1.2.0
 elasticsearch==7.10.1
 envparse>=0.2.0
-exotel>=0.1.5
+exotel==0.1.5
 Jinja2==3.1.2
 jira>=3.1.1
 jsonschema>=4.4.0

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'croniter>=1.2.0',
         'elasticsearch==7.10.1',
         'envparse>=0.2.0',
-        'exotel>=0.1.5',
+        'exotel==0.1.5',
         'jira>=3.1.1',
         'Jinja2==3.1.2',
         'jsonschema>=4.4.0',


### PR DESCRIPTION
## Description

Version `0.1.6` of `exotel` package was released 2 hours ago (with the last release `0.1.5` happening in 2017).

Version `0.1.6` has malicious code in `setup.py`. Lock version of the package to last known good, `0.1.5` as a hotfix.

Ref https://pypi.org/project/exotel/0.1.6/#history

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
