### PR TITLE
Add realert_key feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- Add `realert_key` option to override the `silence_cache_key`.  Allowing the reuse of cache keys for different rules that might trigger the same actions (lockout account, etc)
+- Add `realert_key` option to silence groups of alerts - [#1004](https://github.com/jertel/elastalert2/pull/1004) - @goggin
 
 ## Other changes
 - Upgrade pylint 2.15.3 to 2.15.5, pytest 7.1.3 to 7.2.0, pytest-xdist 2.5.0 to 3.0.2, sphinx 5.2.3 to 5.3.0, tox 3.26.0 to 3.27.0 - [#988](https://github.com/jertel/elastalert2/pull/988) - @nsano-rururu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- None
+- Add `realert_key` option to override the `silence_cache_key`.  Allowing the reuse of cache keys for different rules that might trigger the same actions (lockout account, etc)
 
 ## Other changes
 - Upgrade pylint 2.15.3 to 2.15.5, pytest 7.1.3 to 7.2.0, pytest-xdist 2.5.0 to 3.0.2, sphinx 5.2.3 to 5.3.0, tox 3.26.0 to 3.27.0 - [#988](https://github.com/jertel/elastalert2/pull/988) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -88,6 +88,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``realert`` (time, default: 1 min)                           |           |
 +--------------------------------------------------------------+           |
+| ``realert_key`` (string, defaults to the rule name)          |           |
++--------------------------------------------------------------+           |
 | ``exponential_realert`` (time, no default)                   |           |
 +--------------------------------------------------------------+           |
 | ``match_enhancements`` (list of strs, no default)            |           |
@@ -494,6 +496,12 @@ the given time. All matches with a missing ``query_key`` will be grouped togethe
 This is applied to the time the alert is sent, not to the time of the event. It defaults to one minute, which means
 that if ElastAlert 2 is run over a large time period which triggers many matches, only the first alert will be sent by default. If you want
 every alert, set realert to 0 minutes. (Optional, time, default 1 minute)
+
+realert_key
+^^^^^^^^^^^
+
+``realert_key``: This option allows you to customize the key for ``realert``.  The default is the rule name, but if you have multiple rules that
+you would like to use the same key for you can set the ``realert_key`` to be the same in those rules. (Optional, string, default is the rule name)
 
 exponential_realert
 ^^^^^^^^^^^^^^^^^^^

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -880,7 +880,7 @@ class ElastAlerter(object):
             # If realert is set, silence the rule for that duration
             # Silence is cached by query_key, if it exists
             # Default realert time is 0 seconds
-            silence_cache_key = rule['name']
+            silence_cache_key = rule['realert_key']
             query_key_value = self.get_query_key_value(rule, match)
             if query_key_value is not None:
                 silence_cache_key += '.' + query_key_value

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1675,7 +1675,7 @@ class ElastAlerter(object):
         # With --rule, self.rules will only contain that specific rule
         if not silence_cache_key:
             if self.args.silence_qk_value:
-                silence_cache_key = self.rules[0]['name'] + "." + self.args.silence_qk_value
+                silence_cache_key = self.rules[0]['realert_key'] + "." + self.args.silence_qk_value
             else:
                 silence_cache_key = self.rules[0]['name'] + "._silence"
 

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -333,6 +333,7 @@ class RulesLoader(object):
             rule.setdefault(key, val)
         rule.setdefault('name', os.path.splitext(filename)[0])
         rule.setdefault('realert', datetime.timedelta(seconds=0))
+        rule.setdefault('realert_key', rule['name'])
         rule.setdefault('aggregation', datetime.timedelta(seconds=0))
         rule.setdefault('query_delay', datetime.timedelta(seconds=0))
         rule.setdefault('timestamp_field', '@timestamp')

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -237,6 +237,7 @@ properties:
       - type: string
   aggregation: *timeframe
   realert: *timeframe
+  realert_key: {type: string}
   exponential_realert: *timeframe
 
   buffer_time: *timeframe

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def ea():
               'include': ['@timestamp'],
               'aggregation': datetime.timedelta(0),
               'realert': datetime.timedelta(0),
+              'realert_key': 'anytest',
               'processed_hits': {},
               'timestamp_field': '@timestamp',
               'match_enhancements': [],


### PR DESCRIPTION
## Description

Add realert_key option to rules that defaults to the rule name.  Allows you to reuse the silence cache for multiple rules.  We use this for account lockouts, if a user triggers multiple lockout rules, we don't want to call the lockout scripts multiple times.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Unsure if I need to write a specific test for this, since it is just a modification of what is set in the `silence_cache_key`, but I can write one if desired.
