### PR TITLE
Add slack_webhook_url_env  option to store slack_webhook_url in environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- None
+- Add `slack_webhook_url_env` option to store `slack_webhook_url` in environment variables
 
 ## Other changes
 - [Docs] Clarify Jira Cloud authentication configuration - [94f7e8c](https://github.com/jertel/elastalert2/commit/94f7e8cc98d59a00349e3b23acd8a8549c80dbc8) - @jertel

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3025,6 +3025,8 @@ and copy the resulting URL. You can use a list of URLs to send to multiple chann
 
 Optional:
 
+``slack_webhook_url_env``: The name of the environment variable that specifies slack_webhook_url. May be very useful when sending messages to different channels for different rules
+
 ``slack_username_override``: By default Slack will use your username when posting to the channel. Use this option to change it (free text).
 
 ``slack_channel_override``: Incoming webhooks have a default channel, but it can be overridden. A public channel can be specified "#other-channel", and a Direct Message with "@username".

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -618,6 +618,7 @@ properties:
 
   ### Slack
   slack_webhook_url: *arrayOfString
+  slack_webhook_url_env: {type: string}
   slack_username_override: {type: string}
   slack_channel_override: *arrayOfString
   slack_emoji_override: {type: string}

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -415,6 +415,11 @@ def build_es_conn_config(conf):
 
     if 'es_url_prefix' in conf:
         parsed_conf['es_url_prefix'] = conf['es_url_prefix']
+    
+    if 'slack_webhook_url_env' in conf:
+        parsed_conf['slack_webhook_url'] = os.environ.get(slack_webhook_url_env)    
+    elif 'slack_webhook_url' in conf:
+        parsed_conf['slack_webhook_url'] = conf['slack_webhook_url']
 
     return parsed_conf
 


### PR DESCRIPTION
## Description
Add `slack_webhook_url_env` option to store `slack_webhook_url` in environment variables. May be very useful when sending messages to different channels for different rules
## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
