### PR TITLE
Alerta matches fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.TBD.TBD
 
 ## Breaking changes
-- None
+- [Alerta] All matches will now be sent with the alert - [#1068](https://github.com/jertel/elastalert2/pull/1068) - @dakotacody
 
 ## New features
 - None

--- a/elastalert/alerters/alerta.py
+++ b/elastalert/alerters/alerta.py
@@ -48,7 +48,7 @@ class AlertaAlerter(Alerter):
         headers = {'content-type': 'application/json'}
         if self.api_key is not None:
             headers['Authorization'] = 'Key %s' % (self.rule['alerta_api_key'])
-        alerta_payload = self.get_json_payload(matches[0])
+        alerta_payload = self.get_json_payload(matches)
 
         try:
             response = requests.post(self.url, data=alerta_payload, headers=headers, verify=self.verify_ssl)
@@ -70,7 +70,7 @@ class AlertaAlerter(Alerter):
         return {'type': 'alerta',
                 'alerta_url': self.url}
 
-    def get_json_payload(self, match):
+    def get_json_payload(self, matches):
         """
             Builds the API Create Alert body, as in
             http://alerta.readthedocs.io/en/latest/api/reference.html#create-an-alert
@@ -79,6 +79,8 @@ class AlertaAlerter(Alerter):
 
         """
 
+        # use the first match in the list for setting attributes
+        match = matches[0]
         # Using default text and event title if not defined in rule
         alerta_text = self.rule['type'].get_match_str([match]) if self.text == '' else resolve_string(self.text, match, self.missing_text)
         alerta_event = self.create_default_title([match]) if self.event == '' else resolve_string(self.event, match, self.missing_text)
@@ -108,7 +110,7 @@ class AlertaAlerter(Alerter):
             'correlate': [resolve_string(an_event, match, self.missing_text) for an_event in self.correlate],
             'attributes': dict(list(zip(self.attributes_keys,
                                         [resolve_string(a_value, match, self.missing_text) for a_value in self.attributes_values]))),
-            'rawData': self.create_alert_body([match]),
+            'rawData': self.create_alert_body(matches),
         }
 
         try:

--- a/tests/alerters/alerta_test.py
+++ b/tests/alerters/alerta_test.py
@@ -883,11 +883,11 @@ def test_get_json_payload_error():
         'alert': 'alerta',
         'query_key': 'hostname'
     }
-    match = {
+    match = [{
         '@timestamp': '2014-10-10T00:00:00',
         'sender_ip': '1.1.1.1',
         'hostname': 'aProbe'
-    }
+    }]
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = AlertaAlerter(rule)


### PR DESCRIPTION
## Description

<!--
Update alerta alerter to accept a list of matches instead of just the first match.  Still set attributes from the first match to maintain compatibility with existing deployments using the old logic of just a single match. 

Update the alerta unit tests to send the test as a list too. 
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x ] I have included unit tests for my changes or additions.
- [x ] I have successfully run `make test-docker` with my changes.
- [x ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
Did not update the elastalert documentation because this change does not affect the usage of the alerter, it fixes the functionality to work with other existing settings as expected. 
-->
