### PR TITLE
[docs] Clarify that import supports a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Other changes
 - [Docs] Clarify Jira Cloud authentication configuration - [94f7e8c](https://github.com/jertel/elastalert2/commit/94f7e8cc98d59a00349e3b23acd8a8549c80dbc8) - @jertel
 - Update minimum versions for third-party dependencies in requirements.txt and setup.py - [#1051](https://github.com/jertel/elastalert2/pull/1051) - @nsano-rururu
+- [Docs] Clarify `import` support for list of files [#1075](https://github.com/jertel/elastalert2/pull/1075) - @sqrooted
 
 # 2.9.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -315,7 +315,8 @@ import
 
 ``import``: If specified includes all the settings from this yaml file. This allows common config options to be shared. Note that imported files that aren't
 complete rules should not have a ``.yml`` or ``.yaml`` suffix so that ElastAlert 2 doesn't treat them as rules. Filters in imported files are merged (ANDed)
-with any filters in the rule. You can only have one import per rule, though the imported file can import another file or multiple files, recursively.
+with any filters in the rule. You can have one import per rule (value is string) or several imports per rule (value is a list of strings).
+The imported file can import another file or multiple files, recursively.
 The filename can be an absolute path or relative to the rules directory. (Optional, string or array of strings, no default)
 
 use_ssl


### PR DESCRIPTION
## Description

Ref #580 - current documentation is misleading --  it's now possible to have a rule import multiple additional configuration files, ie:

```yaml
# my-rule.yml
name: my-rule
import:
  - $HOME/conf.d/base.yml
  - $HOME/conf.d/slack-alerter.yml
```

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


