### PR TITLE
fix scan timeframe with use_terms_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add support for Kibana 8.6 for Kibana Discover - [#1080](https://github.com/jertel/elastalert2/pull/1080) - @nsano-rururu
 - Modify schema to allow string and boolean for `*_ca_certs` to allow for one to specify a cert bundle for SSL certificate verification - [#1082](https://github.com/jertel/elastalert2/pull/1082) - @goggin
 - Fix UnicodeEncodeError in PagerDutyAlerter - [#1091](https://github.com/jertel/elastalert2/pull/1091) - @nsano-rururu
+- The scan_entire_timeframe setting, when used with use_count_query or use_terms_query will not scan entire timeframe on subsequent rule runs - [#1097](https://github.com/jertel/elastalert2/pull/1097) - @rschirin
   
 # 2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Add support for Kibana 8.6 for Kibana Discover - [#1080](https://github.com/jertel/elastalert2/pull/1080) - @nsano-rururu
 - Modify schema to allow string and boolean for `*_ca_certs` to allow for one to specify a cert bundle for SSL certificate verification - [#1082](https://github.com/jertel/elastalert2/pull/1082) - @goggin
 - Fix UnicodeEncodeError in PagerDutyAlerter - [#1091](https://github.com/jertel/elastalert2/pull/1091) - @nsano-rururu
-- The scan_entire_timeframe setting, when used with use_count_query or use_terms_query will not scan entire timeframe on subsequent rule runs - [#1097](https://github.com/jertel/elastalert2/pull/1097) - @rschirin
+- The scan_entire_timeframe setting, when used with use_count_query or use_terms_query will now scan entire timeframe on subsequent rule runs - [#1097](https://github.com/jertel/elastalert2/pull/1097) - @rschirin
   
 # 2.9.0
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -698,7 +698,8 @@ class ElastAlerter(object):
                 # Query from the end of the last run, if it exists, otherwise a run_every sized window
                 rule['starttime'] = rule.get('previous_endtime', endtime - self.run_every)
             else:
-                rule['starttime'] = rule.get('previous_endtime', endtime - rule['timeframe'])
+                #Based on PR 3141 old Yelp/elastalert - rschirin
+                rule['starttime'] = endtime - rule['timeframe']
 
     def adjust_start_time_for_overlapping_agg_query(self, rule):
         if rule.get('aggregation_query_element'):

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -876,11 +876,31 @@ def test_set_starttime(ea):
     ea.set_starttime(ea.rules[0], end)
     assert ea.rules[0]['starttime'] == end - ea.buffer_time
 
-    # scan_entire_timeframe
-    ea.rules[0].pop('previous_endtime')
+    # scan_entire_timeframe without use_count_query or use_terms_query
     ea.rules[0].pop('starttime')
     ea.rules[0]['timeframe'] = datetime.timedelta(days=3)
     ea.rules[0]['scan_entire_timeframe'] = True
+    with mock.patch.object(ea, 'get_starttime') as mock_gs:
+        mock_gs.return_value = None
+        ea.set_starttime(ea.rules[0], end)
+    assert ea.rules[0]['starttime'] == end - datetime.timedelta(days=3)
+
+    # scan_entire_timeframe with use_count_query, first run
+    ea.rules[0].pop('starttime')
+    ea.rules[0]['timeframe'] = datetime.timedelta(days=3)
+    ea.rules[0]['scan_entire_timeframe'] = True
+    ea.rules[0]['use_count_query'] = True
+    with mock.patch.object(ea, 'get_starttime') as mock_gs:
+        mock_gs.return_value = None
+        ea.set_starttime(ea.rules[0], end)
+    assert ea.rules[0]['starttime'] == end - datetime.timedelta(days=3)
+
+    # scan_entire_timeframe with use_count_query, subsequent run
+    ea.rules[0].pop('starttime')
+    ea.rules[0]['timeframe'] = datetime.timedelta(days=3)
+    ea.rules[0]['scan_entire_timeframe'] = True
+    ea.rules[0]['use_count_query'] = True
+    ea.rules[0]['previous_endtime'] = end
     with mock.patch.object(ea, 'get_starttime') as mock_gs:
         mock_gs.return_value = None
         ea.set_starttime(ea.rules[0], end)


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->
Following issue [https://github.com/Yelp/elastalert/issues/3041](https://github.com/Yelp/elastalert/issues/3041) and PR [https://github.com/Yelp/elastalert/pull/3141](https://github.com/Yelp/elastalert/pull/3141), when a rule has `[scan_entire_timeframe: true] and [use_terms_query: true or use_count_query: true]`, the timeframe (i.e. 5 days) is evaluated correctly just at first run; from the second one, the timeframe will be set accordly to `run_every` value (i.e. 5 minutes).
This change only affects rules with option use_count_query or use_term_query.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
