### PR TITLE
Remove hardcoded file loader from test_rule.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking changes
 - [Alerta] All matches will now be sent with the alert - [#1068](https://github.com/jertel/elastalert2/pull/1068) - @dakotacody
+- Renamed the `overwrites` parameter to `overrides` in the load_conf method of config.py
 
 ## New features
 - [Graylog GELF] Alerter added. [#1050](https://github.com/jertel/elastalert2/pull/1050) - @malinkinsa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 - [Alerta] All matches will now be sent with the alert - [#1068](https://github.com/jertel/elastalert2/pull/1068) - @dakotacody
-- Renamed the `overwrites` parameter to `overrides` in the load_conf method of config.py
+- Renamed the `overwrites` parameter to `overrides` in the load_conf method of config.py - [#1100](https://github.com/jertel/elastalert2/pull/1100) - @akusei
 
 ## New features
 - [Graylog GELF] Alerter added. [#1050](https://github.com/jertel/elastalert2/pull/1050) - @malinkinsa

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: all production test docs clean
 
+COMPOSE = "-compose"
+ifeq ($(shell docker$(COMPOSE) 2> /dev/null),)
+	COMPOSE = " compose"
+endif
+
 all: production
 
 production:
@@ -20,9 +25,9 @@ test-elasticsearch:
 	tox -c tests/tox.ini -- --runelasticsearch
 
 test-docker:
-	docker-compose -f tests/docker-compose.yml --project-name elastalert build tox
-	docker-compose -f tests/docker-compose.yml --project-name elastalert run --rm tox \
-        tox -c tests/tox.ini -- $(filter-out $@,$(MAKECMDGOALS))
+	$(shell echo docker$(COMPOSE)) -f tests/docker-compose.yml --project-name elastalert build tox
+	$(shell echo docker$(COMPOSE)) -f tests/docker-compose.yml --project-name elastalert run --rm tox \
+		tox -c tests/tox.ini -- $(filter-out $@,$(MAKECMDGOALS))
 
 clean:
 	make -C docs clean

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -65,7 +65,7 @@ def load_conf(args, defaults=None, overrides=None):
         if key not in conf:
             conf[key] = value
 
-    for key, value in (overrides.iteritems() if overrides is not None else []):
+    for key, value in (iter(overrides.items()) if overrides is not None else []):
         conf[key] = value
 
     # Make sure we have all required globals

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -35,13 +35,13 @@ loader_mapping = {
 }
 
 
-def load_conf(args, defaults=None, overwrites=None):
+def load_conf(args, defaults=None, overrides=None):
     """ Creates a conf dictionary for ElastAlerter. Loads the global
         config file and then each rule found in rules_folder.
 
         :param args: The parsed arguments to ElastAlert
         :param defaults: Dictionary of default conf values
-        :param overwrites: Dictionary of conf values to override
+        :param overrides: Dictionary of conf values to override
         :return: The global configuration, a dictionary.
         """
     filename = args.config
@@ -65,7 +65,7 @@ def load_conf(args, defaults=None, overwrites=None):
         if key not in conf:
             conf[key] = value
 
-    for key, value in (iter(overwrites.items()) if overwrites is not None else []):
+    for key, value in (overrides.iteritems() if overrides is not None else []):
         conf[key] = value
 
     # Make sure we have all required globals

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -440,11 +440,8 @@ class MockElastAlerter(object):
             'buffer_time': {'minutes': 45},
             'scroll_keepalive': '30s'
         }
-        overwrites = {
-            'rules_loader': 'file',
-        }
 
-        conf = load_conf(self.args, defaults, overwrites)
+        conf = load_conf(self.args, defaults)
         rule_yaml = conf['rules_loader'].load_yaml(self.args.file)
         conf['rules_loader'].load_options(rule_yaml, conf, self.args.file)
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -37,6 +37,48 @@ def test_config_loads():
     assert conf['alert_time_limit'] == datetime.timedelta(days=2)
 
 
+def test_config_defaults():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    test_args = mock.Mock()
+    test_args.config = dir_path + '/example.config.yaml'
+    test_args.rule = None
+    test_args.debug = False
+    test_args.es_debug_trace = None
+
+    conf = load_conf(
+        test_args,
+        defaults={
+            'new_key': 'new_value',
+            'rules_folder': '/new/rules/folder'
+        }
+    )
+
+    assert conf['new_key'] == 'new_value'
+    assert conf['rules_folder'] == '/opt/elastalert/rules'
+
+
+def test_config_overrides():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    test_args = mock.Mock()
+    test_args.config = dir_path + '/example.config.yaml'
+    test_args.rule = None
+    test_args.debug = False
+    test_args.es_debug_trace = None
+
+    conf = load_conf(
+        test_args,
+        overrides={
+            'new_key': 'new_value',
+            'rules_folder': '/new/rules/folder'
+        }
+    )
+
+    assert conf['new_key'] == 'new_value'
+    assert conf['rules_folder'] == '/new/rules/folder'
+
+
 def test_config_loads_ea_execption():
     with pytest.raises(EAException) as ea:
         os.environ['ELASTIC_PASS'] = 'password_from_env'


### PR DESCRIPTION
## Description

This PR is to remove the hardcoded file rule loader when testing with either `elastalert-test-rule` or using `elastalert.test_rule`. Currently the test will only use a file loader regardless of what you have configured for the `rules_loader` setting. This prevents proper testing when a custom rule loader is required for a valid rule to be loaded.

Based on the original commit message, the changes done in that commit don't line up with the message.
```
Added ability for test rule to override loader to use file loader
```
When it actually just hardcodes it to 'file'.

I also renamed the `overwrites` parameter in `config.py` for the `load_conf` method to `overrides`. If this isn't desired, I don't mind dropping this change, it was just a bit of odd wording. The `overwrites` parameter is not being used by the existing code-base so nothing else here needs to change. This will be a breaking change for anyone who is calling load_conf and providing the overwrites as a named parameter. It will need to be renamed to overrides. I'm okay if this change is denied.

I had to modify the Makefile to account for the newer `docker compose` command while maintaining existing functionality with the older `docker-compose` command.

In removing the hardcoded value I noticed there were no unit tests for loading configurations with defaults and overrides so I added them. The tests initially failed as the original for loop on overrides used `iteritems()` rather than the `iter()` method like the `defaults` for loop.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Questions or Comments
