### PR TITLE
Http post2 alternate jinja root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ## New features
 - [Graylog GELF] Alerter added. [#1050](https://github.com/jertel/elastalert2/pull/1050) - @malinkinsa
 - [TheHive] Format `title`, `type`, and `source` with dynamic lookup values - [#1092](https://github.com/jertel/elastalert2/pull/1092) - @fandigunawan
+- [HTTP POST2] `http_post2_payload` and `http_post2_headers` now support multiline JSON strings for better control over jinja templates - @akusei
+- [HTTP POST2] This alerter now supports the use of `jinja_root_name` - @akusei
+- [Rule Testing] The data file passed with `--data` can now contain a single JSON document or a list of JSON objects - @akusei
 
 ## Other changes
 - [Docs] Clarify Jira Cloud authentication configuration - [94f7e8c](https://github.com/jertel/elastalert2/commit/94f7e8cc98d59a00349e3b23acd8a8549c80dbc8) - @jertel
@@ -16,7 +19,10 @@
 - Modify schema to allow string and boolean for `*_ca_certs` to allow for one to specify a cert bundle for SSL certificate verification - [#1082](https://github.com/jertel/elastalert2/pull/1082) - @goggin
 - Fix UnicodeEncodeError in PagerDutyAlerter - [#1091](https://github.com/jertel/elastalert2/pull/1091) - @nsano-rururu
 - The scan_entire_timeframe setting, when used with use_count_query or use_terms_query will now scan entire timeframe on subsequent rule runs - [#1097](https://github.com/jertel/elastalert2/pull/1097) - @rschirin
-  
+- Add new unit tests to cover changes in the HTTP POST2 alerter - @akusei  
+- [Docs] Updated HTTP POST2 documentation to outline changes with payloads, headers and multiline JSON strings - @akusei
+- [HTTP POST2] Additional error checking around rendering and dumping payloads/headers to JSON - @akusei
+
 # 2.9.0
 
 ## Breaking changes

--- a/elastalert/alerters/httppost2.py
+++ b/elastalert/alerters/httppost2.py
@@ -7,8 +7,10 @@ from requests import RequestException
 from elastalert.alerts import Alerter, DateTimeEncoder
 from elastalert.util import lookup_es_key, EAException, elastalert_logger
 
+
 def _json_escape(s):
     return json.encoder.encode_basestring(s)[1:-1]
+
 
 def _escape_all_values(x):
     """recursively rebuilds, and escapes all strings for json, the given dict/list"""

--- a/elastalert/alerters/httppost2.py
+++ b/elastalert/alerters/httppost2.py
@@ -81,6 +81,10 @@ class HTTPPost2Alerter(Alerter):
                 raise ValueError(f"HTTP Post 2: The rendered value for 'http_post2_{field}' contains invalid JSON. "
                                  f"Please check your template syntax: {e}")
 
+            except Exception as e:
+                raise ValueError(f"HTTP Post 2: An unexpected error occurred with the 'http_post2_{field}' value. "
+                                 f"Please check your template syntax: {e}")
+
             for post_key, es_key in list(self.post_raw_fields.items()):
                 payload[post_key] = lookup_es_key(match, es_key)
 

--- a/elastalert/alerters/httppost2.py
+++ b/elastalert/alerters/httppost2.py
@@ -46,9 +46,13 @@ class HTTPPost2Alerter(Alerter):
         """ Each match will trigger a POST to the specified endpoint(s). """
         for match in matches:
             match_js_esc = _escape_all_values(match)
+            match_internal = {
+                self.rule['jinja_root_name']: match_js_esc
+            }
+
             payload = match if self.post_all_values else {}
             payload_template = Template(json.dumps(self.post_payload))
-            payload_res = json.loads(payload_template.render(**match_js_esc))
+            payload_res = json.loads(payload_template.render(**match_js_esc, **match_internal))
             payload = {**payload, **payload_res}
 
             for post_key, es_key in list(self.post_raw_fields.items()):
@@ -62,7 +66,7 @@ class HTTPPost2Alerter(Alerter):
                 requests.packages.urllib3.disable_warnings()
 
             header_template = Template(json.dumps(self.post_http_headers))
-            header_res = json.loads(header_template.render(**match_js_esc))
+            header_res = json.loads(header_template.render(**match_js_esc, **match_internal))
             headers = {
                 "Content-Type": "application/json",
                 "Accept": "application/json;charset=utf-8",

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -14,7 +14,6 @@ from unittest import mock
 
 from elastalert.config import load_conf
 from elastalert.elastalert import ElastAlerter
-from elastalert.util import EAException
 from elastalert.util import elasticsearch_client
 from elastalert.util import lookup_es_key
 from elastalert.util import ts_now
@@ -354,6 +353,8 @@ class MockElastAlerter(object):
             if not self.data:
                 return None
             try:
+                if isinstance(self.data, dict):
+                    self.data = [self.data]
                 self.data.sort(key=lambda x: x[timestamp_field])
                 self.starttime = self.str_to_ts(self.data[0][timestamp_field])
                 self.endtime = self.str_to_ts(self.data[-1][timestamp_field]) + datetime.timedelta(seconds=1)

--- a/tests/alerters/httppost2_test.py
+++ b/tests/alerters/httppost2_test.py
@@ -3,6 +3,7 @@ import logging
 from unittest import mock
 
 import pytest
+import yaml
 from requests import RequestException
 
 from elastalert.alerters.httppost2 import HTTPPost2Alerter
@@ -43,6 +44,44 @@ def test_http_alerter_with_payload(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload as JSON string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "posted_name": "toto"
+          }
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_raw_fields(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -54,6 +93,49 @@ def test_http_alerter_with_payload_raw_fields(caplog):
         'http_post2_static_payload': {'name': 'somestaticname'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'posted_raw_field': 'foobarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_raw_fields_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload and raw fields as JSON string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_raw_fields:
+          posted_raw_field: somefield
+        http_post2_static_payload:
+          name: somestaticname
+        http_post2_payload: |
+          {
+            "posted_name": "toto"
+          }
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -115,6 +197,50 @@ def test_http_alerter_with_payload_raw_fields_overwrite(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_raw_fields_overwrite_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter raw fields overwrite payload as a JSON string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "posted_name": "toto",
+            "overwrite_field": "tata"
+          }
+        http_post2_raw_fields:
+          overwrite_field: somefield
+        http_post2_static_payload:
+          name: somestaticname
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'overwrite_field': 'foobarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_no_clash(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -124,6 +250,42 @@ def test_http_alerter_with_payload_no_clash(caplog):
         'http_post2_payload': {'posted_name': 'toto'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'toto': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_no_clash_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) has no clash with the match fields
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"posted_name": "toto"}
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -181,6 +343,133 @@ def test_http_alerter_with_payload_args_keys(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_args_keys_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the key
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"args_{{some_field}}": "tata"}
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'to\tto'  # include some specially handled control char
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'args_to\tto': 'tata',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_template_error(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = {
+            'name': 'Test HTTP Post Alerter With unexpected template syntax error',
+            'type': 'any',
+            'jinja_root_name': '_data',
+            'http_post2_url': 'http://test.webhook.url',
+            'http_post2_headers': {'header_name': 'toto'},
+            'http_post2_payload': {'posted_name': '{{ _data["titi"] }}'},
+            'alert': []
+        }
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: The value of 'http_post2_payload' has an invalid Jinja2 syntax." in str(error)
+
+
+def test_http_alerter_with_payload_json_decode_error(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = yaml.safe_load(
+            '''
+            name: Test HTTP Post Alerter With json decode error
+            type: any
+            http_post2_url: http://test.webhook.url
+            http_post2_payload: |
+              this is invalid json
+            alert: []
+            '''
+        )
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: The rendered value for 'http_post2_payload' contains invalid JSON." in str(error)
+
+
+def test_http_alerter_with_payload_args_keys_jinja_root(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload args for the key using custom jinja root
+        type: any
+        jinja_root_name: _data
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "args_{{_data['key1']}}": "tata",
+            "args_{{_data["key2"]}}": "toto"
+          }
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'key1': 'ta\tta',  # include some specially handled control char
+        'key2': 'to\tto',
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'args_to\tto': 'toto',
+        'args_ta\tta': 'tata',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_nested_keys(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -190,6 +479,44 @@ def test_http_alerter_with_payload_nested_keys(caplog):
         'http_post2_payload': {'key': {'nested_key': 'some_value_{{some_field}}'}},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'toto'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'key': {'nested_key': 'some_value_toto'},
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_nested_keys_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the key
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "key": {"nested_key": "some_value_{{some_field}}"}
+          }
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -247,6 +574,42 @@ def test_http_alerter_with_payload_none_value(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_none_value_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the key
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"key": null}
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'toto'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'key': None,
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_args_key_not_found(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -256,6 +619,42 @@ def test_http_alerter_with_payload_args_key_not_found(caplog):
         'http_post2_payload': {'args_{{some_field1}}': 'tata'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'toto'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'args_': 'tata',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_args_key_not_found_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the key if not found
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"args_{{some_field1}}": "tata"}
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -314,6 +713,124 @@ def test_http_alerter_with_payload_args_value(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_args_value_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        """
+        name: Test HTTP Post Alerter With Payload as json string and args for the value
+        type: any
+        http_post2_url: 'http://test.webhook.url'
+        http_post2_payload: |
+          {
+            "posted_name": "toto",
+            "args_name": "{{some_field}}"
+          }
+        alert: []
+        """
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'foo\tbar\nbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'args_name': 'foo\tbar\nbaz',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_args_value_jinja_root(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test HTTP Post Alerter With Payload args for the value using custom jinja root',
+        'jinja_root_name': '_data',
+        'type': 'any',
+        'http_post2_url': 'http://test.webhook.url',
+        'http_post2_payload': {'posted_name': 'toto', 'args_name': "{{_data['some_field']}}"},
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'foo\tbar\nbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'args_name': 'foo\tbar\nbaz',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_args_value_jinja_root_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the value using custom jinja root
+        jinja_root_name: _data
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "posted_name": "toto",
+            "args_name1": "{{_data['some_field']}}",
+            "args_name2": "{{_data["some_field"]}}"
+          }
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'foo\tbar\nbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'args_name1': 'foo\tbar\nbaz',
+        'args_name2': 'foo\tbar\nbaz',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_args_value_not_found(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -323,6 +840,46 @@ def test_http_alerter_with_payload_args_value_not_found(caplog):
         'http_post2_payload': {'posted_name': 'toto', 'args_name': '{{some_field1}}'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'some_field': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        'args_name': '',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_payload_args_value_not_found_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string) args for the value if not found
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {
+            "posted_name": "toto",
+            "args_name": "{{some_field1}}"
+          }
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -383,6 +940,45 @@ def test_http_alerter_with_header_no_clash(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_header_no_clash_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers has no clash with the match fields
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_name": "titi"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_name': 'titi'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_header_args_value(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -393,6 +989,172 @@ def test_http_alerter_with_header_args_value(caplog):
         'http_post2_payload': {'posted_name': 'toto'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foo\tbarbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_name': 'foo\tbarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_args_value_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers args value
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_name": "{{titi}}"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foo\tbarbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_name': 'foo\tbarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_template_error(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = {
+            'name': 'Test HTTP Post Alerter With Headers args template error',
+            'jinja_root_name': '_data',
+            'type': 'any',
+            'http_post2_url': 'http://test.webhook.url',
+            'http_post2_headers': {'header_name': '{{ _data["titi"] }}'},
+            'http_post2_payload': {'posted_name': 'toto'},
+            'alert': []
+        }
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: The value of 'http_post2_headers' has an invalid Jinja2 syntax." in str(error)
+
+
+def test_http_alerter_with_header_json_decode_error(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = yaml.safe_load(
+            '''
+            name: Test HTTP Post Alerter With Headers args json decode error
+            type: any
+            http_post2_url: http://test.webhook.url
+            http_post2_headers: |
+              this is invalid json
+            http_post2_payload:
+              posted_name: toto
+            alert: []
+            '''
+        )
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: The rendered value for 'http_post2_headers' contains invalid JSON." in str(error)
+
+
+def test_http_alerter_with_header_args_value_jinja_root(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test HTTP Post Alerter With Headers args value using custom jinja root',
+        'jinja_root_name': '_data',
+        'type': 'any',
+        'http_post2_url': 'http://test.webhook.url',
+        'http_post2_headers': {'header_name': "{{_data['titi']}}"},
+        'http_post2_payload': {'posted_name': 'toto'},
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foo\tbarbaz'  # include some specially handled control chars
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_name': 'foo\tbarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_args_value_jinja_root_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers args value using custom jinja root
+        type: any
+        jinja_root_name: _data
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_name": "{{_data['titi']}}"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -442,6 +1204,34 @@ def test_http_alerter_with_header_args_value_list(caplog):
            "Forbidden header header_name: ['test1', 'test2']" in str(error)
 
 
+def test_http_alerter_with_header_args_value_list_as_json_string(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = yaml.safe_load(
+            '''
+            name: Test HTTP Post Alerter With Headers args value as json string
+            type: any
+            http_post2_url: http://test.webhook.url
+            http_post2_headers: |
+              {"header_name": ["test1", "test2"]}
+            http_post2_payload:
+              posted_name: toto
+            alert: []
+            '''
+        )
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: Can't send a header value which is not a string! " \
+           "Forbidden header header_name: ['test1', 'test2']" in str(error)
+
+
 def test_http_alerter_with_header_args_value_dict(caplog):
     with pytest.raises(ValueError) as error:
         rule = {
@@ -452,6 +1242,34 @@ def test_http_alerter_with_header_args_value_dict(caplog):
             'http_post2_payload': {'posted_name': 'toto'},
             'alert': []
         }
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: Can't send a header value which is not a string! " \
+           "Forbidden header header_name: {'test': 'val'}" in str(error)
+
+
+def test_http_alerter_with_header_args_value_dict_as_json_string(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = yaml.safe_load(
+            '''
+            name: Test HTTP Post Alerter With Headers args value as json string
+            type: any
+            http_post2_url: http://test.webhook.url
+            http_post2_headers: |
+              {"header_name": {"test": "val"}}
+            http_post2_payload:
+              posted_name: toto
+            alert: []
+            '''
+        )
         rules_loader = FileRulesLoader({})
         rules_loader.load_modules(rule)
         alert = HTTPPost2Alerter(rule)
@@ -490,6 +1308,34 @@ def test_http_alerter_with_header_args_value_none(caplog):
            "Forbidden header header_name: None" in str(error)
 
 
+def test_http_alerter_with_header_args_value_none_as_json_string(caplog):
+    with pytest.raises(ValueError) as error:
+        rule = yaml.safe_load(
+            '''
+            name: Test HTTP Post Alerter With Headers args value as json string
+            type: any
+            http_post2_url: http://test.webhook.url
+            http_post2_headers: |
+              {"header_name": null}
+            http_post2_payload:
+              posted_name: toto
+            alert: []
+            '''
+        )
+        rules_loader = FileRulesLoader({})
+        rules_loader.load_modules(rule)
+        alert = HTTPPost2Alerter(rule)
+        match = {
+            '@timestamp': '2017-01-01T00:00:00',
+            'titi': 'foobarbaz'
+        }
+        with mock.patch('requests.post'):
+            alert.alert([match])
+
+    assert "HTTP Post 2: Can't send a header value which is not a string! " \
+           "Forbidden header header_name: None" in str(error)
+
+
 def test_http_alerter_with_header_args_value_not_found(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -500,6 +1346,45 @@ def test_http_alerter_with_header_args_value_not_found(caplog):
         'http_post2_payload': {'posted_name': 'toto'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_name': ''
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_args_value_not_found_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers args value if not found as json string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_name": "{{titi1}}"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -560,6 +1445,81 @@ def test_http_alerter_with_header_args_key(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_header_args_key_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers args key as json string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_{{titi}}": "tata"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_foobarbaz': 'tata'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_args_key_jinja_root(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test HTTP Post Alerter With Headers args key using custom jinja root',
+        'jinja_root_name': '_data',
+        'type': 'any',
+        'http_post2_url': 'http://test.webhook.url',
+        'http_post2_headers': {"header_{{_data['titi']}}": 'tata'},
+        'http_post2_payload': {'posted_name': 'toto'},
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2023-01-01T00:00:00',
+        'titi': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_foobarbaz': 'tata'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_header_args_key_not_found(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -570,6 +1530,45 @@ def test_http_alerter_with_header_args_key_not_found(caplog):
         'http_post2_payload': {'posted_name': 'toto'},
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'titi': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;charset=utf-8',
+        'header_': 'tata'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers=expected_headers,
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
+def test_http_alerter_with_header_args_key_not_found_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Headers args key if not found as json string
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_headers: |
+          {"header_{{titi1}}": "tata"}
+        http_post2_payload:
+          posted_name: toto
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)
@@ -628,6 +1627,42 @@ def test_http_alerter_with_payload_nested(caplog):
     assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
 
 
+def test_http_alerter_with_payload_nested_as_json_string(caplog):
+    caplog.set_level(logging.INFO)
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"posted_name": "{{ toto.tata }}"}
+        alert: []
+        '''
+    )
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'toto': {'tata': 'titi'}
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'titi',
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert ('elastalert', logging.INFO, 'HTTP Post 2 alert sent.') == caplog.record_tuples[0]
+
+
 def test_http_alerter_with_payload_all_values():
     rule = {
         'name': 'Test HTTP Post Alerter With Payload',
@@ -637,6 +1672,43 @@ def test_http_alerter_with_payload_all_values():
         'http_post2_all_values': True,
         'alert': []
     }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = HTTPPost2Alerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'posted_name': 'toto',
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post2_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None,
+        timeout=10,
+        verify=True
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
+def test_http_alerter_with_payload_all_values_as_json_string():
+    rule = yaml.safe_load(
+        '''
+        name: Test HTTP Post Alerter With Payload (as JSON string)
+        type: any
+        http_post2_url: http://test.webhook.url
+        http_post2_payload: |
+          {"posted_name": "toto"}
+        http_post2_all_values: true
+        alert: []
+        '''
+    )
     rules_loader = FileRulesLoader({})
     rules_loader.load_modules(rule)
     alert = HTTPPost2Alerter(rule)

--- a/tests/alerters/httppost2_test.py
+++ b/tests/alerters/httppost2_test.py
@@ -424,7 +424,7 @@ def test_http_alerter_with_payload_unexpected_error(caplog):
         with mock.patch('requests.post'):
             alert.alert([match])
 
-    assert "HTTP Post 2: An unexpected error occurred with the 'http_post2_{field}' value." in str(error)
+    assert "HTTP Post 2: An unexpected error occurred with the 'http_post2_payload' value." in str(error)
 
 
 def test_http_alerter_with_payload_json_decode_error(caplog):


### PR DESCRIPTION
## Description

* Added support for multiline JSON strings in YAML fields (similar to alert_text)
```yaml
    http_post2_payload: |
      {
        "description": "An event came from IP {{ _data["client.ip"] }}",
        "username": "{{ _data['username'] }}"
        {%- for k, v in some_field.items() -%}
        ,"{{ k }}": "changed_{{ v }}"
        {%- endfor -%}
      }
    http_post2_headers: |
      {
        "authorization": "Basic 123dr3234",
        "X-custom-{{key}}": "{{type}}"
      }
```

* Added `jinja_root_name` support to the HTTP POST2 alerter
* Changed the `--data` argument for rule testing to accept both a file with a single JSON document or a file with a proper JSON list of objects
Example file with single JSON object
```json
{"fieldname": "value"}
```
Example file with list of JSON objects:
```json
[{"fieldname":"value1"},{"fieldname":"value2"}]
```
* Additional error checking has been added around JSON decoding and jinja templates for HTTP POST2 headers and payloads

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

The change to `--data` for rule testing was added just for convenience. I was doing some testing and didn't realize the document needed to be a list of JSON objects. I didn't see anything stating it needed to be a list so I changed the code to allow for a single JSON object in the file or a list of JSON objects. The intent of this PR was not to make this change so if it's not wanted I'm okay with removing it
