### PR TITLE
Multiple alert message config

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1654,6 +1654,38 @@ come from an individual event, usually the one which triggers the alert.
 
 When using ``alert_text_args``, you can access nested fields and index into arrays. For example, if your match was ``{"data": {"ips": ["127.0.0.1", "12.34.56.78"]}}``, then by using ``"data.ips[1]"`` in ``alert_text_args``, it would replace value with ``"12.34.56.78"``. This can go arbitrarily deep into fields and will still work on keys that contain dots themselves.
 
+Multiple Alert Subject and Alert Content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to have different alert topics and content for each alert you can suffix the alert name to the following keys:
+	- ``alert_subject``
+	- ``alert_subject_args``
+	- ``alert_subject_max_len``
+	- ``alert_text_type``
+	- ``alert_text``
+	- ``alert_text_args``
+	- ``alert_text_kw``
+	
+For example for an email and slack alert:
+
+.. code-block:: yaml
+	alert_subject_email: "Email Alert"
+	alert_text_email: "email"
+	
+	alert_subject_slack: "Slack Alert"
+	alert_text_slack: "slack"
+
+This setting in your rule file will cause different alert messages to be sent for both slack and email platforms.
+
+.. _commonconfig:
+
+.. note:: If you do not define any of these specific keys, the generic ones (without suffix) will be used.
+
+
+This feature is available for the following alerts:
+	- email
+	- slack 
+
 Alerter
 ~~~~~~~
 

--- a/elastalert/alerters/email.py
+++ b/elastalert/alerters/email.py
@@ -18,7 +18,7 @@ class EmailAlerter(Alerter):
     required_options = frozenset(['email'])
 
     def __init__(self, *args):
-        super(EmailAlerter, self).__init__(*args)
+        super(EmailAlerter, self).__init__(*args, alerter="email")
 
         self.assets_dir = self.rule.get('assets_dir', '/tmp')
         self.images_dictionary = dict(zip(self.rule.get('email_image_keys', []),  self.rule.get('email_image_values', [])))

--- a/elastalert/alerters/slack.py
+++ b/elastalert/alerters/slack.py
@@ -13,7 +13,7 @@ class SlackAlerter(Alerter):
     required_options = frozenset(['slack_webhook_url'])
 
     def __init__(self, rule):
-        super(SlackAlerter, self).__init__(rule)
+        super(SlackAlerter, self).__init__(rule, alerter="slack")
         self.slack_webhook_url = self.rule.get('slack_webhook_url', None)
         if isinstance(self.slack_webhook_url, str):
             self.slack_webhook_url = [self.slack_webhook_url]


### PR DESCRIPTION
## Description
Hello, I am using eslastalert in my company, I noticed that in each .yml recipe of a rule, only one message body can be defined. But in the company we need slack and email messages to have different information. I added this feature in this pull request. 

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

If you think it's worth it I can do a unit test and add the feachure to the other alerts to complete the pull request requirements.

This new feature allows both general and specific settings to coexist. If there is a specific configuration for an alert, the general one will be omitted. For example:
```
alert_text: hello
alert_text_email: email

alert:
-  email
-  slack
```
In this case the slack alert will use the general message and the email alert the specific one.

