### PR TITLE
Additional EQL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## New features
 - Add initial support for EQL - [#1189](https://github.com/jertel/elastalert2/pull/1189) - @jertel
+- Add EQL support to elastalert-test-rule utility - [#1195](https://github.com/jertel/elastalert2/pull/1195) - @jertel
 
 ## Other changes
 - Add support for Kibana 8.8 for Kibana Discover - [#1184](https://github.com/jertel/elastalert2/pull/1184) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -997,6 +997,8 @@ guaranteed to have the exact same results as with Elasticsearch. For example, an
    and flatline require a minimum elapsed time before they begin alerting, based on their timeframe. In addition, use_count_query and
    use_terms_query rely on run_every to determine their resolution. This script uses a fixed 5 minute window, which is the same as the default.
 
+   Also, EQL filters do not support counts, so the output relating to counts may show N/A (Not Applicable).
+
 
 .. _ruletypes:
 

--- a/elastalert/eql.py
+++ b/elastalert/eql.py
@@ -47,5 +47,6 @@ def format_results(results):
     # relabel events as hits, for consistency
     events = hits.pop('events')
     hits['hits'] = events
+    results['eql'] = True
 
     return results

--- a/elastalert/test_rule.py
+++ b/elastalert/test_rule.py
@@ -211,25 +211,28 @@ class MockElastAlerter(object):
 
         terms = res['hits']['hits'][0]['_source']
 
-        # Get a count of all docs
-        count_query = ElastAlerter.get_query(
-            conf['filter'],
-            starttime=self.starttime,
-            endtime=self.endtime,
-            timestamp_field=ts,
-            to_ts_func=conf['dt_to_ts'],
-            sort=False
-        )
-        try:
-            res = es_client.count(index=index, body=count_query, ignore_unavailable=True)
-        except Exception as e:
-            print("Error querying Elasticsearch:", file=sys.stderr)
-            print(repr(e)[:2048], file=sys.stderr)
-            if self.args.stop_error:
-                exit(2)
-            return None
+        is_eql = res.get('eql') == True
 
-        num_hits = res['count']
+        if not is_eql:
+            # Get a count of all docs
+            count_query = ElastAlerter.get_query(
+                conf['filter'],
+                starttime=self.starttime,
+                endtime=self.endtime,
+                timestamp_field=ts,
+                to_ts_func=conf['dt_to_ts'],
+                sort=False
+            )
+            try:
+                res = es_client.count(index=index, body=count_query, ignore_unavailable=True)
+            except Exception as e:
+                print("Error querying Elasticsearch:", file=sys.stderr)
+                print(repr(e)[:2048], file=sys.stderr)
+                if self.args.stop_error:
+                    exit(2)
+                return None
+
+            num_hits = res['count']
 
         if self.args.formatted_output:
             self.formatted_output['hits'] = num_hits
@@ -237,9 +240,14 @@ class MockElastAlerter(object):
             self.formatted_output['terms'] = list(terms.keys())
             self.formatted_output['result'] = terms
         else:
+            if is_eql:
+                count = 'N/A'
+            else:
+                count = num_hits
+
             print(
                 "Got %s hits from the last %s day%s"
-                % (num_hits, self.args.days, "s" if self.args.days > 1 else "")
+                % (count, self.args.days, "s" if self.args.days > 1 else "")
             )
             print("\nAvailable terms in first hit:")
             print_terms(terms, '')
@@ -276,6 +284,9 @@ class MockElastAlerter(object):
                     exit(2)
                 return None
             num_hits = len(res['hits']['hits'])
+
+            if is_eql:
+                self.formatted_output['hits'] = num_hits
 
             if self.args.save:
                 print("Downloaded %s documents to save" % (num_hits))


### PR DESCRIPTION
## Description

Cleaned up new unit tests.
Improve the elastalert-test-rule tool with EQL filters to prevent a benign "count" query error message.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

N/A