### PR TITLE
add log line when exiting due to --end param falling in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for Kibana 8.8 for Kibana Discover - [#1184](https://github.com/jertel/elastalert2/pull/1184) - @nsano-rururu
 - Upgrade pylint 2.17.0 to 2.17.4, pytest 7.2.2 to 7.3.1, pytest-xdist 3.2.0 to 3.3.1, sphinx 6.1.3 to 6.2.1, sphinx_rtd_theme == 1.2.2 - [#1194](https://github.com/jertel/elastalert2/pull/1194) - @nsano-rururu
 - Upgrade to Tox 4 - [#1196](https://github.com/jertel/elastalert2/pull/1196) - @jertel
+- Log message when exiting due to --end param being in the past - [#1199](https://github.com/jertel/elastalert2/pull/1199) - @jertel
 
 # 2.11.0
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1132,9 +1132,9 @@ class ElastAlerter(object):
             if self.args.end:
                 endtime = ts_to_dt(self.args.end)
 
-                dt = next_run.replace(tzinfo=dateutil.tz.tzutc())
-                if dt > endtime:
-                    elastalert_logger.info("End time '%s' falls before the next run time '%s', exiting." % (endtime, dt))
+                next_run_dt = next_run.replace(tzinfo=dateutil.tz.tzutc())
+                if next_run_dt > endtime:
+                    elastalert_logger.info("End time '%s' falls before the next run time '%s', exiting." % (endtime, next_run_dt))
                     exit(0)
 
             if next_run < datetime.datetime.utcnow():

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1132,7 +1132,9 @@ class ElastAlerter(object):
             if self.args.end:
                 endtime = ts_to_dt(self.args.end)
 
-                if next_run.replace(tzinfo=dateutil.tz.tzutc()) > endtime:
+                dt = next_run.replace(tzinfo=dateutil.tz.tzutc())
+                if dt > endtime:
+                    elastalert_logger.info("End time '%s' falls before the next run time '%s', exiting." % (endtime, dt))
                     exit(0)
 
             if next_run < datetime.datetime.utcnow():


### PR DESCRIPTION
## Description

Log a message explaining why ElastAlert 2 is exiting, when --end param is in the past.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [N/A] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [N/A] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
