### PR TITLE
Correct --days description, add --start and --end

### DIFF
--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -987,8 +987,21 @@ and missing or misconfigured fields.
 
 ``--count-only``: Only find the number of matching documents and list available fields. ElastAlert 2 will not be run and documents will not be downloaded.
 
-``--days N``: Instead of the default 1 day, query N days. For selecting more specific time ranges, you must run ElastAlert 2 itself and use ``--start``
+``--days N``: Instead of the default 1 day, query N days. For selecting more specific time ranges, use ``--start``
 and ``--end``.
+
+``--end <timestamp>`` will force ElastAlert 2 to stop querying after the given
+time, instead of the default, querying to the present time. This really only
+makes sense when running standalone. The timestamp is formatted as
+``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00``
+(UTC-XX).
+
+``--start <timestamp>`` will force ElastAlert 2 to begin querying from the given
+time, instead of the default, querying from the present. The timestamp should be
+ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
+``YYYY-MM-DDTHH:MM:SS-08:00`` (PST). Note that if querying over a large date
+range, no alerts will be sent until that rule has finished querying over the
+entire time period. To force querying from the current time, use "NOW".
 
 ``--save-json FILE``: Save all documents downloaded to a file as JSON. This is useful if you wish to modify data while testing or do offline
 testing in conjunction with ``--data FILE``. A maximum of 10,000 documents will be downloaded.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -990,18 +990,13 @@ and missing or misconfigured fields.
 ``--days N``: Instead of the default 1 day, query N days. For selecting more specific time ranges, use ``--start``
 and ``--end``.
 
-``--end <timestamp>`` will force ElastAlert 2 to stop querying after the given
-time, instead of the default, querying to the present time. This really only
-makes sense when running standalone. The timestamp is formatted as
+``--start <timestamp>`` The starting date/time of the search filter's time range. The timestamp is formatted as
 ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00``
-(UTC-XX).
+(UTC-XX). If ``timeframe`` is specified, defaults to the ending time - timeframe. Otherwise defaults to ending time - 1 day.
 
-``--start <timestamp>`` will force ElastAlert 2 to begin querying from the given
-time, instead of the default, querying from the present. The timestamp should be
-ISO8601, e.g.  ``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone
-``YYYY-MM-DDTHH:MM:SS-08:00`` (PST). Note that if querying over a large date
-range, no alerts will be sent until that rule has finished querying over the
-entire time period. To force querying from the current time, use "NOW".
+``--end <timestamp>`` The ending date/time of the search filter's time range. The timestamp is formatted as
+``YYYY-MM-DDTHH:MM:SS`` (UTC) or with timezone ``YYYY-MM-DDTHH:MM:SS-XX:00``
+(UTC-XX). Defaults to the current time.
 
 ``--save-json FILE``: Save all documents downloaded to a file as JSON. This is useful if you wish to modify data while testing or do offline
 testing in conjunction with ``--data FILE``. A maximum of 10,000 documents will be downloaded.


### PR DESCRIPTION
Update documentation:
`--days` info said that `--start` and `--end` don't exist, but they do. 
Correct that line and add `--start` and `--end` info to the page.

## Description

No changes to actual code. Small modification to documentation only.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

changes are only to documentation so no unit tests, make, relevant modes, and items to add to the changelog.
