### PR TITLE
clarify docs. resolves #1206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- [Docs] Clarify docs to state that alert_time_limit should not be 0 - [#xx](https://github.com/jertel/elastalert2/pull/xx) - @jertel
+- [Docs] Clarify docs to state that alert_time_limit should not be 0 - [#1208](https://github.com/jertel/elastalert2/pull/1208) - @jertel
 
 # 2.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- TBD
+- [Docs] Clarify docs to state that alert_time_limit should not be 0 - [#xx](https://github.com/jertel/elastalert2/pull/xx) - @jertel
 
 # 2.12.0
 

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -292,7 +292,7 @@ connections
 ``writeback_index`` is the name of the index in which ElastAlert 2 will store
 data. We will create this index later.
 
-``alert_time_limit`` is the retry window for failed alerts.
+``alert_time_limit`` is the retry window for failed alerts. Must be greater than zero.
 
 Save the file as ``config.yaml``
 


### PR DESCRIPTION
## Description

Clarifies the alert_time_limit docs to state it must be > 0/

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
