### PR TITLE
Update telegram.py to be able to send alerts to Telegram in Markdown format

### DIFF
--- a/elastalert/alerters/telegram.py
+++ b/elastalert/alerters/telegram.py
@@ -26,7 +26,7 @@ class TelegramAlerter(Alerter):
 
     def alert(self, matches):
         if self.telegram_parse_mode != 'html':
-            body = '⚠ *%s* ⚠ ```\n' % (self.create_title(matches))
+            body = '⚠ *%s* ⚠ \n' % (self.create_title(matches))
         else:
             body = '⚠ %s ⚠ \n' % (self.create_title(matches))
 
@@ -39,7 +39,7 @@ class TelegramAlerter(Alerter):
             body = body[0:4000] + "\n⚠ *message was cropped according to telegram limits!* ⚠"
 
         if self.telegram_parse_mode != 'html':
-            body += ' ```'
+            body += ' '
 
         headers = {'content-type': 'application/json'}
         # set https proxy, if it was provided


### PR DESCRIPTION
Hi

## Description

I've been trying to send elastalert alerts in markdown format, although I specify in the alert the parameter telegram_parse_mode: "markdown", this does not work, because in the code of the telegram.py file, it is established that if the text is not html, three quotation marks must be added to the body of the alert. When receiving it in telegram it interprets it as monospaced code, ignoring the markdown format.

Removing the 3 quotes from the function allows elastalert to be able to send the alerts to Telegram in Markdown format.

Thank you for your attention. Regards, 
David Paramio.

![imagen](https://github.com/jertel/elastalert2/assets/16100827/087ac791-d2fd-45ed-9d0e-e871a9307cfa)

## Checklist
- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io/en/latest/).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Questions or Comments
