### PR TITLE
Correct deployment commonLabels indentation for pod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - [Helm] Expose minReadySeconds parameter to assist in detecting failed deployments - [#1243](https://github.com/jertel/elastalert2/pull/1243) - @alexku7 
+- [Helm] Fix commonLabels indentation for the deployment template - [#1250](https://github.com/jertel/elastalert2/pull/1250) - @dan-duffy 
 
 # 2.13.2
 

--- a/chart/elastalert2/templates/deployment.yaml
+++ b/chart/elastalert2/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: {{ .Values.appKubernetesIoComponent }}
         {{- if .Values.commonLabels }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
 {{- if .Values.image.pullSecret }}


### PR DESCRIPTION
## Description
I noticed when using the `commonLabels` value that the deployment was unable to render additional labels correctly. It looks like the pod template specific template's indentation was off by 4 spaces.

## Checklist
- [X] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [X] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments
As this is a minor indentation change specific to the Helm chart, the testing didn't seem to be relevant but please correct me if I'm wrong! I've tested the indentation locally and the manifests seem to be rendering correctly now when adding `commonLabels`.
