### PR TITLE
FlatlineRule: Extract functions that could be overriden by child classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- Refactored FlatlineRule to make it more extensible
+- Refactored FlatlineRule to make it more extensible - [#1291](https://github.com/jertel/elastalert2/pull/1291) - @rundef 
 
 # 2.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.14.1
+# 2.TBD.TBD
 
 ## Breaking changes
 - TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.TBD.TBD
+# 2.14.1
 
 ## Breaking changes
 - TBD
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- TBD
+- Refactored FlatlineRule to make it more extensible
 
 # 2.14.0
 


### PR DESCRIPTION
## Description

In a project, I created a class extending `FlatlineRule` and added some custom code.
However, I had to copy the code of `check_for_match` and `garbage_function` in the children class just to change a few lines of code, which isn't great.

This PR adds:
- a `get_threshold` function (users will be able to override that function in case the threshold changes depending on the key).
- a `get_keys` function (in my case I'm retrieving the keys from an external API)
- a `get_event_data` function (to add custom variable for alerts)

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I did not add any unit tests because there isn't any new feature.
I did not update the documentation because there's no section about extending rules.