### PR TITLE
Added telegram message_thread_id option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - TBD
 
 ## New features
-- TBD
+- [Telegram] Added new telegram_thread_id setting for sending alerts to different threads of supergroup/forum. - [#???](https://github.com/jertel/elastalert2/pull/???) - @polshe-v
 
 ## Other changes
 - Update setup.py & requirements.txt & requirements-dev.txt - [#1316](https://github.com/jertel/elastalert2/pull/1316) - @nsano-rururu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - TBD
 
 ## New features
-- [Telegram] Added new telegram_thread_id setting for sending alerts to different threads of supergroup/forum. - [#???](https://github.com/jertel/elastalert2/pull/???) - @polshe-v
+- [Telegram] Added new telegram_thread_id setting for sending alerts to different threads of supergroup/forum. - [#1319](https://github.com/jertel/elastalert2/pull/1319) - @polshe-v
 
 ## Other changes
 - Update setup.py & requirements.txt & requirements-dev.txt - [#1316](https://github.com/jertel/elastalert2/pull/1316) - @nsano-rururu

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -3688,6 +3688,8 @@ Optional:
 
 ``telegram_parse_mode``: The Telegram parsing mode, which determines the format of the alert text body. Possible values are ``markdown``, ``markdownV2``, ``html``. Defaults to ``markdown``.
 
+``telegram_thread_id``: Unique identifier for the target thread of supergroup/forum using telegram message_thread_id (Optional, positive integer value, no default).
+
 Example usage::
 
     alert:

--- a/elastalert/alerters/telegram.py
+++ b/elastalert/alerters/telegram.py
@@ -51,7 +51,7 @@ class TelegramAlerter(Alerter):
             'text': body,
             'parse_mode': self.telegram_parse_mode,
             'disable_web_page_preview': True,
-            'message_thread_id': self.self.telegram_thread_id
+            'message_thread_id': self.telegram_thread_id
         }
 
         try:

--- a/elastalert/alerters/telegram.py
+++ b/elastalert/alerters/telegram.py
@@ -23,6 +23,7 @@ class TelegramAlerter(Alerter):
         self.telegram_proxy_login = self.rule.get('telegram_proxy_login', None)
         self.telegram_proxy_password = self.rule.get('telegram_proxy_pass', None)
         self.telegram_parse_mode = self.rule.get('telegram_parse_mode', 'markdown')
+        self.telegram_thread_id = self.rule.get('telegram_thread_id', None)
 
     def alert(self, matches):
         if self.telegram_parse_mode != 'html':
@@ -49,7 +50,8 @@ class TelegramAlerter(Alerter):
             'chat_id': self.telegram_room_id,
             'text': body,
             'parse_mode': self.telegram_parse_mode,
-            'disable_web_page_preview': True
+            'disable_web_page_preview': True,
+            'message_thread_id': self.self.telegram_thread_id
         }
 
         try:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -773,6 +773,7 @@ properties:
   telegram_proxy_login: {type: string}
   telegram_proxy_pass: {type: string}
   telegram_parse_mode: {type: string, enum: ['markdown', 'markdownV2', 'html']}
+  telegram_thread_id: {type: number}
 
   ### Tencent SMS
   tencent_sms_secret_id: {type: string}

--- a/tests/alerters/telegram_test.py
+++ b/tests/alerters/telegram_test.py
@@ -33,10 +33,10 @@ def test_telegram_thread_id(caplog):
         alert.alert([match])
     expected_data = {
         'chat_id': rule['telegram_room_id'],
-        'text': '⚠ Test Telegram Rule ⚠ \nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
+        'text': '⚠ *Test Telegram Rule* ⚠ ```\nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n ```',
         'parse_mode': 'markdown',
         'disable_web_page_preview': True,
-        'message_thread_id' : 2
+        'message_thread_id': 2
     }
 
     mock_post_request.assert_called_once_with(
@@ -74,7 +74,8 @@ def test_telegram_markdown(caplog):
         'chat_id': rule['telegram_room_id'],
         'text': '⚠ *Test Telegram Rule* ⚠ ```\nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n ```',
         'parse_mode': 'markdown',
-        'disable_web_page_preview': True
+        'disable_web_page_preview': True,
+        'message_thread_id': None
     }
 
     mock_post_request.assert_called_once_with(
@@ -113,7 +114,8 @@ def test_telegram_html(caplog):
         'chat_id': rule['telegram_room_id'],
         'text': '⚠ Test Telegram Rule ⚠ \nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
         'parse_mode': 'html',
-        'disable_web_page_preview': True
+        'disable_web_page_preview': True,
+        'message_thread_id': None
     }
 
     mock_post_request.assert_called_once_with(
@@ -153,7 +155,8 @@ def test_telegram_proxy():
         'chat_id': rule['telegram_room_id'],
         'text': '⚠ *Test Telegram Rule* ⚠ ```\nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n ```',
         'parse_mode': 'markdown',
-        'disable_web_page_preview': True
+        'disable_web_page_preview': True,
+        'message_thread_id': None
     }
 
     mock_post_request.assert_called_once_with(
@@ -190,7 +193,8 @@ def test_telegram_text_maxlength():
         'text': '⚠ *Test Telegram Rule' + ('a' * 3979) +
                 '\n⚠ *message was cropped according to telegram limits!* ⚠ ```',
         'parse_mode': 'markdown',
-        'disable_web_page_preview': True
+        'disable_web_page_preview': True,
+        'message_thread_id': None
     }
 
     mock_post_request.assert_called_once_with(
@@ -315,7 +319,8 @@ def test_telegram_matchs():
                 '----------------------------------------\n' +
                 ' ```',
         'parse_mode': 'markdown',
-        'disable_web_page_preview': True
+        'disable_web_page_preview': True,
+        'message_thread_id': None
     }
 
     mock_post_request.assert_called_once_with(

--- a/tests/alerters/telegram_test.py
+++ b/tests/alerters/telegram_test.py
@@ -12,6 +12,46 @@ from elastalert.loaders import FileRulesLoader
 from elastalert.util import EAException
 
 
+def test_telegram_thread_id(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test Telegram Rule',
+        'type': 'any',
+        'telegram_bot_token': 'xxxxx1',
+        'telegram_room_id': 'xxxxx2',
+        'telegram_thread_id': 2,
+        'alert': []
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = TelegramAlerter(rule)
+    match = {
+        '@timestamp': '2021-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'chat_id': rule['telegram_room_id'],
+        'text': '⚠ Test Telegram Rule ⚠ \nTest Telegram Rule\n\n@timestamp: 2021-01-01T00:00:00\nsomefield: foobarbaz\n',
+        'parse_mode': 'markdown',
+        'disable_web_page_preview': True,
+        'message_thread_id' : 2
+    }
+
+    mock_post_request.assert_called_once_with(
+        'https://api.telegram.org/botxxxxx1/sendMessage',
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        auth=None
+    )
+
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+    assert ('elastalert', logging.INFO, 'Alert sent to Telegram room xxxxx2') == caplog.record_tuples[0]
+
+
 def test_telegram_markdown(caplog):
     caplog.set_level(logging.INFO)
     rule = {


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->
I wanted to sort alerts sent to Telegram, because I have different log sources and there are so many types of them, therefore so many chats. But having multiple Telegram chats for every source type is not convenient (chaotic chats order, difficult managing `telegram_room_id` in rules). 

Now Telegram has a feature of supergroups/forums where you can create threads. Using this supergroup/forum I can have all my alerts in 1 chat and sort them in threads. So I decided to add an option for `message_thread_id` of Telegram sendMessage function.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
