### PR TITLE
Fix percentiles aggregation type in Spike Metric Aggregation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Other changes
 - Update setup.py & requirements.txt & requirements-dev.txt - [#1316](https://github.com/jertel/elastalert2/pull/1316) - @nsano-rururu
 - [Docs] Clarify how to reference query_key values in flatline alerts - [#1320](https://github.com/jertel/elastalert2/pull/1320) - @jertel
+- Fix percentiles aggregation type in Spike Metric Aggregation rules - [#1323](https://github.com/jertel/elastalert2/pull/1323) - @jertel
 
 # 2.15.0
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -448,15 +448,16 @@ class SpikeRule(RuleType):
         extending ref/cur value retrieval logic for spike aggregations
         """
         spike_check_type = self.rules.get('metric_agg_type')
-        if spike_check_type in [None, 'sum', 'value_count', 'cardinality', 'percentile']:
-            # default count logic is appropriate in all these cases
-            return self.ref_windows[qk].count(), self.cur_windows[qk].count()
-        elif spike_check_type == 'avg':
+        if spike_check_type == 'avg':
             return self.ref_windows[qk].mean(), self.cur_windows[qk].mean()
         elif spike_check_type == 'min':
             return self.ref_windows[qk].min(), self.cur_windows[qk].min()
         elif spike_check_type == 'max':
             return self.ref_windows[qk].max(), self.cur_windows[qk].max()
+ 
+        # default count logic is appropriate in all other cases
+        return self.ref_windows[qk].count(), self.cur_windows[qk].count()
+
 
     def clear_windows(self, qk, event):
         # Reset the state and prevent alerts until windows filled again

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -18,6 +18,7 @@ from elastalert.ruletypes import MetricAggregationRule
 from elastalert.ruletypes import NewTermsRule
 from elastalert.ruletypes import PercentageMatchRule
 from elastalert.ruletypes import RuleType
+from elastalert.ruletypes import SpikeMetricAggregationRule
 from elastalert.ruletypes import SpikeRule
 from elastalert.ruletypes import WhitelistRule
 from elastalert.util import dt_to_ts
@@ -1400,3 +1401,29 @@ def test_comparerule_compare():
         assert False
     except NotImplementedError:
         assert True
+
+
+def test_spike_percentiles():
+    rules = {'buffer_time': datetime.timedelta(minutes=5),
+             'timeframe': datetime.timedelta(minutes=5),
+             'timestamp_field': '@timestamp',
+             'metric_agg_type': 'percentiles',
+             'metric_agg_key': 'bytes',
+             'percentile_range': 95,
+             'spike_type': 'up',
+             'spike_height': 1.5,
+             'min_threshold': 0.0}
+
+    rule = SpikeMetricAggregationRule(rules)
+
+    payload1 = {"metric_bytes_percentiles": {"values": {"95.0": 0.0}}}
+    timestamp1 = datetime.datetime.now() - datetime.timedelta(minutes=600)
+    data1 = {timestamp1: payload1}
+    rule.add_aggregation_data(data1)
+    assert len(rule.matches) == 0
+
+    payload2 = {"metric_bytes_percentiles": {"values": {"95.0": 9879.0}}}
+    timestamp2 = datetime.datetime.now()
+    data2 = {timestamp2: payload2}
+    rule.add_aggregation_data(data2)
+    assert len(rule.matches) == 1


### PR DESCRIPTION
## Description

Corrects a logic flaw and typo for Spike Metric Aggregation rules using the `percentiles` aggregation.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
