### PR TITLE
Bugfix compound query_key and mixed mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - [Docs] Extend FAQ / troubleshooting section with information on Elasticsearch RBAC - [#1324](https://github.com/jertel/elastalert2/pull/1324) - @chr-b
 - Upgrade to Python 3.12 - [#1327](https://github.com/jertel/elastalert2/pull/1327) - @jertel
 - Correction in IRIS and GELF alerter [#1331](https://github.com/jertel/elastalert2/pull/1331) - @malinkinsa
+- Fix handing of compound_query_key values - [#1330](https://github.com/jertel/elastalert2/pull/1330) - @jmacdone
+- Fix handing raw_query_key and query_key values ending with .keyword- [#1330](https://github.com/jertel/elastalert2/pull/1330) - @jmacdone
 - [Docs] Fix broken search function caused by sphinx upgrade a few releases ago - [#1332](https://github.com/jertel/elastalert2/pull/1332) - @jertel
 - [Docs] Fix mismatch for parameter iris_customer_id - [1334](https://github.com/jertel/elastalert2/pull/1334) @malinkinsa
 - [IRIS] Make parameter iris_customer_id optional with default value - [1334](https://github.com/jertel/elastalert2/pull/1334) @malinkinsa

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -466,7 +466,7 @@ class ElastAlerter(object):
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
         rule_filter = copy.copy(rule['filter'])
         if qk:
-            qk_list = qk.split(",")
+            qk_list = qk.split(", ")
             end = '.keyword'
 
             if len(qk_list) == 1:

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -477,11 +477,10 @@ class ElastAlerter(object):
                 rule_filter.extend([{'term': {filter_key: qk}}])
             else:
                 filter_keys = rule['compound_query_key']
-                for i in range(len(filter_keys)):
-                    key_with_postfix = filter_keys[i]
-                    if rule.get('raw_count_keys', True) and not key.endswith(end):
-                        key_with_postfix = add_keyword_postfix(key_with_postfix)
-                    rule_filter.extend([{'term': {key_with_postfix: qk_list[i]}}])
+                for i,filter_key in enumerate(filter_keys):
+                    if rule.get('raw_count_keys', True) and not filter_key.endswith(end):
+                        filter_key = add_keyword_postfix(filter_key)
+                    rule_filter.extend([{'term': {filter_key: qk_list[i]}}])
 
         base_query = self.get_query(
             rule_filter,

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -66,6 +66,12 @@ def _find_es_dict_by_key(lookup_dict, term):
     """
     if term in lookup_dict:
         return lookup_dict, term
+
+    if term.endswith('.keyword'):
+        term, _, _ = term.partition('.keyword')
+        if term in lookup_dict:
+            return lookup_dict, term
+
     # If the term does not match immediately, perform iterative lookup:
     # 1. Split the search term into tokens
     # 2. Recurrently concatenate these together to traverse deeper into the dictionary,

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
                             'elastalert=elastalert.elastalert:main']},
     packages=find_packages(exclude=["tests"]),
     package_data={'elastalert': ['schema.yaml', 'es_mappings/**/*.json']},
+    python_requires='>=3.9',
     install_requires=[
         'apscheduler>=3.10.4,<4.0',
         'aws-requests-auth>=0.4.3',

--- a/tests/hits_terms_test.py
+++ b/tests/hits_terms_test.py
@@ -29,11 +29,70 @@ def example_agg_response():
     return res
 
 
-def test_query_key_filter_happy_path(ea, example_agg_response):
+def _mock_query_key_option_loader(rule):
+    '''
+    So, some copypasta from loaders.load_options,
 
-    ea.rules[0]['compound_query_key'] = ['server_ip', 'service_name']
-    qk = ('172.16.1.10', '/api/v1/endpoint-foo')
-    qk_csv = ", ".join(qk)
+    if query_key is a string:
+        no compound_query_key is created
+    if query_key is a list:
+        if len() > 1:
+            compound_query_key is created
+            query_key is replaced with ",".join() of the original query_key values
+        if len() == 1:
+            the query_key list with one string is normalilzed back to just a string
+        if len() == 0:
+            somehow it was an empty list and query_keys is silently dropped from the config
+    '''
+    raw_query_key = rule.get('query_key')
+    if isinstance(raw_query_key, list):
+        if len(raw_query_key) > 1:
+            rule['compound_query_key'] = raw_query_key
+            rule['query_key'] = ','.join(raw_query_key)
+        elif len(raw_query_key) == 1:
+            rule['query_key'] = raw_query_key[0]
+        else:
+            del(rule['query_key'])
+
+@pytest.mark.parametrize(
+    ["qk", "query_key"],
+
+    #scenario A: 3 query keys
+    [ ( ['172.16.1.10', '/api/v1/endpoint-foo', 'us-east-2'],
+        ['server_ip', 'service_name', 'region'] ),
+
+    #scenario B: 2 query keys
+      ( ['172.16.1.10', '/api/v1/endpoint-foo'],
+        ['server_ip', 'service_name'] ),
+
+    #scenario C: 1 query key, but it was given as a list of one fieldname in the rule options
+      ( ['172.16.1.10'],
+        ['server_ip'] ),
+
+    #scenario D: 1 query key, given as a string
+      ( ['172.16.1.10'],
+        'server_ip' ),
+
+    #scenario E: no query key
+      ( None,
+        None )
+   ],
+)
+def test_query_key_filter_happy_path(ea, example_agg_response, qk, query_key):
+
+    if query_key is not None:
+        ea.rules[0]['query_key'] = query_key
+
+    # emulate the rule['compound_query_key'] creation logic which prob should be
+    # factored out of loaders.load_options() instead of copypasta'd for the test
+    _mock_query_key_option_loader(ea.rules[0])
+
+    try:
+        # todo: why are these values being passed as a commaspace-join and not a
+        # comma-join like everything else?
+        qk_csv = ", ".join(qk)
+    except TypeError:
+        qk_csv = None
     index = 'foo-2023-13-13' #lousy Smarch weather
     top_term_key = 'client_ip'
 
@@ -54,12 +113,22 @@ def test_query_key_filter_happy_path(ea, example_agg_response):
     assert hit_terms[endtime] == example_agg_response['aggregations']['counts']['buckets']
 
     expected_filters = [
-        {'range': {'@timestamp': {
-            'gt': dt_to_ts(starttime),
-            'lte': dt_to_ts(endtime)}}},
-        {'term': {f'{ea.rules[0]['compound_query_key'][0]}.keyword': qk[0]}},
-        {'term': {f'{ea.rules[0]['compound_query_key'][1]}.keyword': qk[1]}}
+        {'range': {'@timestamp': { 'gt': dt_to_ts(starttime), 'lte': dt_to_ts(endtime)}}}
     ]
+    try:
+        cqk = ea.rules[0]['compound_query_key']
+        for fieldname, value in zip(cqk, qk):
+            filter = {'term': {f'{fieldname}.keyword': value}}
+            expected_filters.append(filter)
+    except KeyError:
+        #not a compound, eh?  it must be a string of a single filedname
+        try:
+            fieldname = ea.rules[0]['query_key']
+            filter = {'term': {f'{fieldname}.keyword': qk[0]}}
+            expected_filters.append(filter)
+        except KeyError:
+            pass # maybe the rule never had a query_key, or it was an empty list and purged
+
     expected_query = {
         'query': {'bool': {'filter': {'bool': {'must': expected_filters}}}},
          # 50 harded coded in get_hits_terms as a default for size=None

--- a/tests/hits_terms_test.py
+++ b/tests/hits_terms_test.py
@@ -1,9 +1,12 @@
 import pytest
-from datetime import datetime,timedelta
+from datetime import datetime, timedelta
 
 from elastalert.util import dt_to_ts
 from elastalert.elastalert import ElastAlerter
 
+# I like the dictionary whitespace the way it is, thank you
+# but I'm not going to tag all the lines with #noqa: E201
+# flake8: noqa
 
 @pytest.fixture
 def example_agg_response():
@@ -15,7 +18,7 @@ def example_agg_response():
             'total': {'value': 9, 'relation': 'eq'},
             'max_score': None,
             'hits': []},
-        'aggregations':{
+        'aggregations': {
             'counts': {
                 'doc_count_error_upper_bound': 0,
                 'sum_other_doc_count': 0,
@@ -53,29 +56,30 @@ def _mock_query_key_option_loader(rule):
         elif len(raw_query_key) == 1:
             rule['query_key'] = raw_query_key[0]
         else:
-            del(rule['query_key'])
+            del rule['query_key']
+
 
 @pytest.mark.parametrize(
     ["qk_value", "query_key"],
 
-    #scenario A: 3 query keys
+    # scenario A: 3 query keys
     [ ( ['172.16.1.10', '/api/v1/endpoint-foo', 'us-east-2'],
         ['server_ip', 'service_name', 'region'] ),
 
-    #scenario B: 2 query keys
+    # scenario B: 2 query keys
       ( ['172.16.1.10', '/api/v1/endpoint-foo'],
         ['server_ip', 'service_name'] ),
 
-    #scenario C: 1 query key, but it was given as a list of one fieldname in the rule options
-    #as of this writing, 707b2a5 shouldn't allow this to happen, but here is a test regardless
+    # scenario C: 1 query key, but it was given as a list of one fieldname in the rule options
+    # as of this writing, 707b2a5 shouldn't allow this to happen, but here is a test regardless
       ( ['172.16.1.10'],
         ['server_ip'] ),
 
-    #scenario D: 1 query key, given as a string
+    # scenario D: 1 query key, given as a string
       ( ['172.16.1.10'],
         'server_ip' ),
 
-    #scenario E: no query key
+    # scenario E: no query key
       ( None,
         None )
    ],

--- a/tests/hits_terms_test.py
+++ b/tests/hits_terms_test.py
@@ -80,7 +80,8 @@ def _mock_query_key_option_loader(rule):
         None )
    ],
 )
-def test_get_hits_terms_with_factored_out_filters(ea, example_agg_response, qk_value, query_key):
+@pytest.mark.parametrize("query_key_values_separator", [",", ", ", ",      ", ",\t"])
+def test_get_hits_terms_with_factored_out_filters(ea, example_agg_response, qk_value, query_key, query_key_values_separator):
 
     if query_key is not None:
         ea.rules[0]['query_key'] = query_key
@@ -92,7 +93,7 @@ def test_get_hits_terms_with_factored_out_filters(ea, example_agg_response, qk_v
     try:
         # ElastAlert.process_hits() is expected to insert the filedname values
         # from _hits as a commaspace csv
-        qk_csv = ", ".join(qk_value)
+        qk_csv = query_key_values_separator.join(qk_value)
     except TypeError:
         qk_csv = None
     index = 'foo-2023-13-13' #lousy Smarch weather
@@ -146,10 +147,11 @@ def test_query_key_filters_single_query_key():
     expected_filters = [{'term': {f'{rule['query_key']}.keyword': qk_value_csv}}]
     assert filters == expected_filters
 
-def test_query_key_filters_compound_query_key():
+@pytest.mark.parametrize("query_key_values_separator", [",", ", ", ",      ", ",\t"])
+def test_query_key_filters_compound_query_key(query_key_values_separator):
     rule = { 'query_key': 'compound,key',
              'compound_query_key': ['compound', 'key'] }
-    qk_value_csv = 'combined value, by commaspace'
+    qk_value_csv = query_key_values_separator.join( ['combined value', 'by commaspace'] )
     filters = list(ElastAlerter.query_key_filters(rule,qk_value_csv))
     expected_filters = [
         {'term': {'compound.keyword': 'combined value'}},

--- a/tests/hits_terms_test.py
+++ b/tests/hits_terms_test.py
@@ -1,0 +1,68 @@
+import pytest
+from datetime import datetime,timedelta
+
+from elastalert.util import dt_to_ts
+
+
+@pytest.fixture
+def example_agg_response():
+    res = {
+        'took': 1,
+        'timed_out': False,
+        '_shards': {'total': 3, 'successful': 3, 'skipped': 0, 'failed': 0},
+        'hits': {
+            'total': {'value': 9, 'relation': 'eq'},
+            'max_score': None,
+            'hits': []},
+        'aggregations':{
+            'counts': {
+                'doc_count_error_upper_bound': 0,
+                'sum_other_doc_count': 0,
+                'buckets': [{'key': '10.0.4.174', 'doc_count': 2},
+                            {'key': '10.0.4.241', 'doc_count': 2},
+                            {'key': '10.0.4.76', 'doc_count': 1},
+                            {'key': '10.0.4.123', 'doc_count': 1},
+                            {'key': '10.0.4.156', 'doc_count': 1},
+                            {'key': '10.0.4.231', 'doc_count': 1},
+                            {'key': '10.0.4.248', 'doc_count': 1}]}}
+    }
+    return res
+
+
+def test_query_key_filter_happy_path(ea, example_agg_response):
+
+    ea.rules[0]['compound_query_key'] = ['server_ip', 'service_name']
+    qk = ('172.16.1.10', '/api/v1/endpoint-foo')
+    qk_csv = ", ".join(qk)
+    index = 'foo-2023-13-13' #lousy Smarch weather
+    top_term_key = 'client_ip'
+
+    endtime = datetime.now()
+    starttime = endtime - timedelta(hours=1)
+    ea.thread_data.current_es.search.return_value = example_agg_response
+
+    hit_terms = ea.get_hits_terms(
+        rule=ea.rules[0],
+        starttime=starttime,
+        endtime=endtime,
+        index=index,
+        key=top_term_key,
+        qk = qk_csv,
+        size=None
+    )
+    assert endtime in hit_terms
+    assert hit_terms[endtime] == example_agg_response['aggregations']['counts']['buckets']
+
+    expected_filters = [
+        {'range': {'@timestamp': {
+            'gt': dt_to_ts(starttime),
+            'lte': dt_to_ts(endtime)}}},
+        {'term': {f'{ea.rules[0]['compound_query_key'][0]}.keyword': qk[0]}},
+        {'term': {f'{ea.rules[0]['compound_query_key'][1]}.keyword': qk[1]}}
+    ]
+    expected_query = {
+        'query': {'bool': {'filter': {'bool': {'must': expected_filters}}}},
+         # 50 harded coded in get_hits_terms as a default for size=None
+        'aggs': {'counts': {'terms': {'field': top_term_key, 'size': 50, 'min_doc_count': 1}}}
+    }
+    ea.thread_data.current_es.search.assert_called_with(index=index,body=expected_query, size=0, ignore_unavailable=True)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -117,6 +117,7 @@ def test_looking_up_nested_keys(ea):
     }
 
     assert lookup_es_key(record, 'Fields.ts') == expected
+    assert lookup_es_key(record, 'Fields.ts.keyword') == expected
 
 
 def test_looking_up_nested_composite_keys(ea):
@@ -131,6 +132,7 @@ def test_looking_up_nested_composite_keys(ea):
     }
 
     assert lookup_es_key(record, 'Fields.ts.value') == expected
+    assert lookup_es_key(record, 'Fields.ts.value.keyword') == expected
 
 
 def test_looking_up_arrays(ea):
@@ -148,10 +150,14 @@ def test_looking_up_arrays(ea):
     assert lookup_es_key(record, 'flags[0]') == 1
     assert lookup_es_key(record, 'flags[1]') == 2
     assert lookup_es_key(record, 'objects[0]foo') == 'bar'
+    assert lookup_es_key(record, 'objects[0]foo.keyword') == 'bar'
     assert lookup_es_key(record, 'objects[1]foo[0]bar') == 'baz'
     assert lookup_es_key(record, 'objects[2]foo.bar') == 'baz'
+    assert lookup_es_key(record, 'objects[2]foo.bar.keyword') == 'baz'
     assert lookup_es_key(record, 'objects[1]foo[1]bar') is None
+    assert lookup_es_key(record, 'objects[1]foo[1]bar.keyword') is None
     assert lookup_es_key(record, 'objects[1]foo[0]baz') is None
+    assert lookup_es_key(record, 'objects[1]foo[0]baz.keyword') is None
     assert lookup_es_key(record, 'nested.foo[0]') == 'bar'
     assert lookup_es_key(record, 'nested.foo[1]') == 'baz'
 


### PR DESCRIPTION
## Description

Fixes to allow top_count_keys to still function when using a list of query_key values.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

tl;dr fc583f77fb6c3eb134ddd3164c908441c3086898 and e0795fe556a8b9b72aaf305237f8f5c72823ab84 are bug fixes.   9d1f291e24c9ef8d5ae246a281eae5a06cd770f2 is a guess.


I didn't attempt unit tests as a. `get_hits_terms` looks strongly coupled with elasticsearch results and b. there wasn't an existing get_hits_terms unit test (that I could find) 

Confirmed through manual testing that a single query_key still behaves as before and the list of query_key values now populates top_events_* as expected. 

I have low confidence 9d1f291e24c9ef8d5ae246a281eae5a06cd770f2 is the correct way to handle `raw_count_keys=false` but it's working (finally) as expected, when dealing with a mix of `text` terms and `keyword`, `ip`, `int`, etc. terms.  As it stands now, with this PR, a rule with this config works as I expect.

```
query_key:
  - serialnumber.keyword
  - src_computer.keyword

top_count_keys:
  - src_displayname.keyword
  - src_computer.keyword
  - src_uid    # mapping type: keyword
  - src        # mapping of type: ip
 
raw_count_keys: false
```

Manual testing done on a python 3.11 image (similar to the Dockerfile) with vscode debugger checkpoints around the changes
```
"dev.containers.source": "https://github.com/devcontainers/images",
"dev.containers.variant": "3.11-bookworm"
```

`make test-docker`
> py311: OK (585.32=setup[491.51]+cmd[91.95,1.86] seconds)
> docs: OK (492.05=setup[476.75]+cmd[15.30] seconds)
> congratulations :) (1077.43 seconds)