### PR TITLE
Fix issue in IRIS docs and alerter required options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 - Support hourly index patterns - [#1328](https://github.com/jertel/elastalert2/pull/1328) - @jmacdone
 - Correction in IRIS and GELF alerter [#1331](https://github.com/jertel/elastalert2/pull/1331) - @malinkinsa
 - [Docs] Fix broken search function caused by sphinx upgrade a few releases ago - [#1332](https://github.com/jertel/elastalert2/pull/1332) - @jertel
-- [Docs] Fix mismatch for parameter iris_customer_id - []() @malinkinsa
-- [IRIS] Make parameter iris_customer_id optional with default value - []() @malinkinsa
+- [Docs] Fix mismatch for parameter iris_customer_id - [1334](https://github.com/jertel/elastalert2/pull/1334) @malinkinsa
+- [IRIS] Make parameter iris_customer_id optional with default value - [1334](https://github.com/jertel/elastalert2/pull/1334) @malinkinsa
 
 # 2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Support hourly index patterns - [#1328](https://github.com/jertel/elastalert2/pull/1328) - @jmacdone
 - Correction in IRIS and GELF alerter [#1331](https://github.com/jertel/elastalert2/pull/1331) - @malinkinsa
 - [Docs] Fix broken search function caused by sphinx upgrade a few releases ago - [#1332](https://github.com/jertel/elastalert2/pull/1332) - @jertel
+- [Docs] Fix mismatch for parameter iris_customer_id - []() @malinkinsa
+- [IRIS] Make parameter iris_customer_id optional with default value - []() @malinkinsa
 
 # 2.15.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -2723,9 +2723,9 @@ The alerter requires the following option:
 
 ``iris_api_token``: The API key of the user you created, which will be used to initiate alerts and cases on behalf of this user.
 
-``iris_customer_id``: The user ID associated with the API key mentioned above. You can find it on the same page where the API key is located.
-
 Optional:
+
+``iris_customer_id``: This field represents the unique identifier of the customer for whom an incident/case will be created within the system. Configure and view the existing options in the section ``Advanced -> Customers`` of your IRIS instance. The default value is: ``1``
 
 ``iris_ca_cert``: Set this option to True or a path to a CA cert bundle or directory (eg: /etc/ssl/certs/ca-certificates.crt) to validate the SSL certificate.The default value is: False.
 

--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -9,13 +9,13 @@ from elastalert.util import EAException, elastalert_logger, lookup_es_key
 
 
 class IrisAlerter(Alerter):
-    required_options = set(['iris_host', 'iris_api_token', 'iris_customer_id'])
+    required_options = set(['iris_host', 'iris_api_token'])
 
     def __init__(self, rule):
         super(IrisAlerter, self).__init__(rule)
         self.url = f"https://{self.rule.get('iris_host')}"
         self.api_token = self.rule.get('iris_api_token')
-        self.customer_id = self.rule.get('iris_customer_id')
+        self.customer_id = self.rule.get('iris_customer_id', 1)
         self.ca_cert = self.rule.get('iris_ca_cert')
         self.ignore_ssl_errors = self.rule.get('iris_ignore_ssl_errors', False)
         self.description = self.rule.get('iris_description', None)

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -326,7 +326,6 @@ def test_iris_alert_alert(caplog):
         'type': 'any',
         'iris_host': '127.0.0.1',
         'iris_api_token': 'token 12345',
-        'iris_customer_id': 1,
         'iris_description': 'test description in alert',
         'iris_alert_note': 'test note',
         'iris_alert_tags': 'test, alert',
@@ -371,6 +370,100 @@ def test_iris_alert_alert(caplog):
         "alert_note": 'test note',
         "alert_tags": 'test, alert',
         "alert_customer_id": 1,
+        "alert_source_link": 'https://example.com',
+        "alert_iocs": [
+            {
+                'ioc_description': 'source address',
+                'ioc_tags': 'ip, ipv4',
+                'ioc_tlp_id': 1,
+                'ioc_type_id': 76,
+                'ioc_value': '172.20.1.1'
+            },
+            {
+                'ioc_description': 'target username',
+                'ioc_tags': 'login, username',
+                'ioc_tlp_id': 3,
+                'ioc_type_id': 3,
+                'ioc_value': 'evil_user'
+            }
+        ],
+        "alert_context": {
+            'username': 'evil_user',
+            'ip': '172.20.1.1',
+            'login_status': 'success'
+        },
+    }
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    with mock.patch('requests.post', return_value=mock_response) as mock_post_request:
+        alert.alert([match])
+
+    mock_post_request.assert_called_once_with(
+        url=f'https://{rule["iris_host"]}/alerts/add',
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {rule["iris_api_token"]}'
+        },
+        json=mock.ANY,
+        verify=True,
+    )
+
+    assert expected_data == mock_post_request.call_args_list[0][1]['json']
+    assert ('elastalert', logging.INFO, 'Alert sent to Iris') == caplog.record_tuples[0]
+
+
+def test_iris_alert_alert_with_custom_customer_id(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test Main',
+        'type': 'any',
+        'iris_host': '127.0.0.1',
+        'iris_api_token': 'token 12345',
+        'iris_customer_id': 2,
+        'iris_description': 'test description in alert',
+        'iris_alert_note': 'test note',
+        'iris_alert_tags': 'test, alert',
+        'iris_overwrite_timestamp': True,
+        'iris_alert_source_link': 'https://example.com',
+        'iris_iocs': [
+            {
+                'ioc_description': 'source address',
+                'ioc_tags': 'ip, ipv4',
+                'ioc_tlp_id': 1,
+                'ioc_type_id': 76,
+                'ioc_value': 'src_ip'
+            },
+            {
+                'ioc_description': 'target username',
+                'ioc_tags': 'login, username',
+                'ioc_tlp_id': 3,
+                'ioc_type_id': 3,
+                'ioc_value': 'username'
+            }
+        ],
+        'iris_alert_context': {'username': 'username', 'ip': 'src_ip', 'login_status': 'event_status'},
+        'alert': [],
+    }
+
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = IrisAlerter(rule)
+
+    match = {
+        '@timestamp': '2023-10-21 20:00:00.000', 'username': 'evil_user', 'src_ip': '172.20.1.1', 'dst_ip': '10.0.0.1',
+        'event_type': 'login', 'event_status': 'success'
+    }
+
+    expected_data = {
+        "alert_title": 'Test Main',
+        "alert_description": 'test description in alert',
+        "alert_source": "ElastAlert2",
+        "alert_severity_id": 1,
+        "alert_status_id": 2,
+        "alert_source_event_time": '2023-10-21 20:00:00.000',
+        "alert_note": 'test note',
+        "alert_tags": 'test, alert',
+        "alert_customer_id": 2,
         "alert_source_link": 'https://example.com',
         "alert_iocs": [
             {


### PR DESCRIPTION
## Description

I found some inaccuracies in the description, which have been corrected. I misunderstood the parameter slightly when adding support. After these changes, it doesn't need to be mandatory anymore, and it can be assigned the default value.

I also displayed scenarios in the tests where it's not set and when it's set to a non-default value.

## Checklist


- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
