### PR TITLE
Use SSLContext for Python 3.12; fixes #1339

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 __pycache__/
 *.pyc
 virtualenv_run/
-.venv
+.venv*
 *.egg-info/
 dist/
 venv/

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -213,7 +213,7 @@ Example usage::
     jira_alert_owner: $owner$
 
 
-.. _alerts:
+.. _alert_types:
 
 Alert Types
 ===========

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -320,7 +320,7 @@ or loaded from a module. For loading from a module, the type should be specified
 alert
 ^^^^^
 
-``alert``: The ``Alerter`` type to use. This may be one or more of the built in alerts, see :ref:`Alert Types <alerts>` section below for more information,
+``alert``: The ``Alerter`` type to use. This may be one or more of the built in alerts, see :ref:`Alert Types <alert_types>` section below for more information,
 or loaded from a module. For loading from a module, the alert should be specified as ``module.file.AlertName``. (Required, string or list, no default)
 
 Optional Settings

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -258,7 +258,7 @@ information. If no filters are desired, it should be specified as an empty list:
 ``filter: []``
 
 ``alert`` is a list of alerts to run on each match. For more information on
-alert types, see :ref:`Alerts <alerts>`. The email alert requires an SMTP server
+alert types, see :ref:`Alert Types <alert_types>`. The email alert requires an SMTP server
 for sending mail. By default, it will attempt to use localhost. This can be
 changed with the ``smtp_host`` option.
 


### PR DESCRIPTION
## Description

Refactors how the email alerter uses certs/keys to support Python 3.12.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
