### PR TITLE
[IRIS] Remove empty IOC in alerts that are not accepted by the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add workwechat alerter - [#1367](https://github.com/jertel/elastalert2/pull/1367) - @wufeiqun
 
 ## Other changes
-- [IRIS] Remove empty IOC in alerts that are not accepter by the API - [#1374](https://github.com/jertel/elastalert2/pull/1374) - @yaksnip425
+- [IRIS] Remove empty IOC in alerts that are not accepted by the API - [#1374](https://github.com/jertel/elastalert2/pull/1374) - @yaksnip425
 
 # 2.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add workwechat alerter - [#1367](https://github.com/jertel/elastalert2/pull/1367) - @wufeiqun
 
 ## Other changes
-- [IRIS] Remove empty IOC in alerts that are not accepter by the API - [#](https://github.com/jertel/elastalert2/pull/) - @yaksnip425
+- [IRIS] Remove empty IOC in alerts that are not accepter by the API - [#1374](https://github.com/jertel/elastalert2/pull/1374) - @yaksnip425
 
 # 2.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add workwechat alerter - [#1367](https://github.com/jertel/elastalert2/pull/1367) - @wufeiqun
 
 ## Other changes
-- TBD
+- [IRIS] Remove empty IOC in alerts that are not accepter by the API - [#](https://github.com/jertel/elastalert2/pull/) - @yaksnip425
 
 # 2.16.0
 

--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -65,7 +65,8 @@ class IrisAlerter(Alerter):
         iocs = []
         for record in self.iocs:
             record['ioc_value'] = lookup_es_key(matches[0], record['ioc_value'])
-            iocs.append(record)
+            if record['ioc_value'] is not None:
+                iocs.append(record)
         return iocs
 
     def make_alert(self, matches):

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -64,6 +64,13 @@ def test_iris_make_iocs_records(caplog):
                 'ioc_tlp_id': 3,
                 'ioc_type_id': 3,
                 'ioc_value': 'username'
+            },
+            {
+                'ioc_description': 'empty ioc',
+                'ioc_tags': 'ioc',
+                'ioc_tlp_id': 3,
+                'ioc_type_id': 3,
+                'ioc_value': 'non_existent_data'
             }
         ],
         'alert': []


### PR DESCRIPTION
## Description

The IRIS API does not accept a null ioc_value for new alerts : ```marshmallow.exceptions.ValidationError: {2: {'ioc_value': ['Field may not be null.']}}```.

The modification removes IOCs that have no values before send the alert to IRIS.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
