### PR TITLE
Fix #1384 - spike aggregation: TypeError: '<' not supported between instances of 'NoneType' and 'int'

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -524,8 +524,8 @@ class SpikeRule(RuleType):
         """ Determines if an event spike or dip happening. """
         # Apply threshold limits
         if self.field_value is None:
-            if (cur < self.rules.get('threshold_cur', 0) or
-                    ref < self.rules.get('threshold_ref', 0)):
+            if ((cur and cur < self.rules.get('threshold_cur', 0)) or
+                    (ref and ref < self.rules.get('threshold_ref', 0))):
                 return False
         elif ref is None or ref == 0 or cur is None or cur == 0:
             return False

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -522,12 +522,15 @@ class SpikeRule(RuleType):
 
     def find_matches(self, ref, cur):
         """ Determines if an event spike or dip happening. """
+        if ref is None or cur is None:
+            return False
+
         # Apply threshold limits
         if self.field_value is None:
-            if ((cur and cur < self.rules.get('threshold_cur', 0)) or
-                    (ref and ref < self.rules.get('threshold_ref', 0))):
+            if (cur < self.rules.get('threshold_cur', 0) or
+                    ref < self.rules.get('threshold_ref', 0)):
                 return False
-        elif ref is None or ref == 0 or cur is None or cur == 0:
+        elif ref == 0 or cur == 0:
             return False
 
         spike_up, spike_down = False, False


### PR DESCRIPTION
This PR fixes issue #1384.