### PR TITLE
Updating the Jira alert for scenarios where we need to create subtask (child issues) within existing tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Renamed PR #1193's `fields` common rule option to `include_fields` due to collision with `new_term` rule type's existing `field` parameter - [#1408](https://github.com/jertel/elastalert2/pull/1408) - @jertel
 
 ## New features
-- None
+- [Jira] Add ability to create a subtask, etc of an existing parent - [#1417](https://github.com/jertel/elastalert2/pull/1417) - @olehpalanskyi
 
 ## Other changes
 - [workwechat] add workwechat msgtype - [#1369](https://github.com/jertel/elastalert2/pull/1369) - @bitqiu

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1195,6 +1195,26 @@ This alert requires four additional options:
 
 Optional:
 
+``jira_parent``: Specify an existing ticket that will be used as a parent to create a new subtask in it
+
+  For example, if you have this issue hierarchy:
+    Epic
+    Story, Task, Bug
+    Subtask
+
+  Then:
+    As a parent issue, an epic can have stories, tasks, and bugs as subtask (child issues).
+    As a parent issues, task, stories and bugs can have subtasks as subtask (child issues).
+    A subtask can’t have any subtask (child issues).
+
+  Example usage::
+
+      jira_server: "https://example.atlassian.net/"
+      jira_project: "XXX"
+      jira_assignee: user@example.com
+      jira_issuetype: "Sub-task"
+      jira_parent: "XXX-3164"
+
 ``jira_assignee``: Assigns an issue to a user.
 
 ``jira_component``: The name of the component or components to set the ticket to. This can be a single string or a list of strings. This is provided for backwards compatibility and will eventually be deprecated. It is preferable to use the plural ``jira_components`` instead.

--- a/elastalert/alerters/jira.py
+++ b/elastalert/alerters/jira.py
@@ -46,6 +46,7 @@ class JiraAlerter(Alerter):
         'jira_server',
         'jira_transition_to',
         'jira_watchers',
+        'jira_parent'
     ]
 
     # Some built-in Jira types that can be used as custom fields require special handling
@@ -66,6 +67,8 @@ class JiraAlerter(Alerter):
         self.get_account(self.rule['jira_account_file'])
         self.project = self.rule['jira_project']
         self.issue_type = self.rule['jira_issuetype']
+        # this parameter use to create subtasks
+        self.parent = self.rule.get('jira_parent', None)
 
         # Deferred settings refer to values that can only be resolved when a match
         # is found and as such loading them will be delayed until we find a match
@@ -126,8 +129,13 @@ class JiraAlerter(Alerter):
             elastalert_logger.error("Priority %s not found. Valid priorities are %s" % (self.priority, list(self.priority_ids.keys())))
 
     def reset_jira_args(self):
-        self.jira_args = {'project': {'key': self.project},
-                          'issuetype': {'name': self.issue_type}}
+        if self.parent:
+            self.jira_args = {'project': {'key': self.project},
+                                'parent': {'key': self.parent},
+                                'issuetype': {'name': self.issue_type}}
+        else:
+            self.jira_args = {'project': {'key': self.project},
+                            'issuetype': {'name': self.issue_type}}
 
         if self.components:
             # Support single component or list


### PR DESCRIPTION
## Description

Problem:
I have a needs create a subtask (child issues) under task, bug, story, epic to keep it under one track.

Solution:
I have extend jira capabilities with a new parameter which help to do that.
By default, it’s off.

jira_parent: Specify an existing ticket that will be used as a parent to create a new subtask in it

For example, if you have this issue hierarchy:
Epic
Story, Task, Bug
Subtask

Then:
As a parent issue, an epic can have stories, tasks, and bugs as subtask (child issues).
As a parent issues, task, stories and bugs can have subtasks as subtask (child issues).
A subtask can’t have any subtask (child issues).

Example usage::
    jira_server: "https://example.atlassian.net/"
    jira_project: "XXX"
    jira_assignee: user@example.com
    jira_issuetype: "Sub-task"
    jira_parent: "XXX-3164"
  
## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
