### PR TITLE
Add pagerduty_ca_certs option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Other changes
 - [workwechat] add workwechat msgtype - [#1369](https://github.com/jertel/elastalert2/pull/1369) - @bitqiu
-- Add options: pagerduty_ca_certs, pagerduty_ignore_ssl_errors - [#1418](https://github.com/jertel/elastalert2/pull/1418) - @kexin-zhai
+- [Pager Duty] Add options: pagerduty_ca_certs, pagerduty_ignore_ssl_errors - [#1418](https://github.com/jertel/elastalert2/pull/1418) - @kexin-zhai
 
 # 2.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - [workwechat] add workwechat msgtype - [#1369](https://github.com/jertel/elastalert2/pull/1369) - @bitqiu
+- Add options: pagerduty_ca_certs, pagerduty_ignore_ssl_errors - [#1418](https://github.com/jertel/elastalert2/pull/1418) - @kexin-zhai
 
 # 2.17.0
 

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1630,6 +1630,10 @@ If there's no open (i.e. unresolved) incident with this key, a new one will be c
 
 ``pagerduty_proxy``: By default ElastAlert 2 will not use a network proxy to send notifications to PagerDuty. Set this option using ``hostname:port`` if you need to use a proxy. only supports https.
 
+``pagerduty_ca_certs``: Set this option to ``True`` or a path to a CA cert bundle or directory (eg: ``/etc/ssl/certs/ca-certificates.crt``) to validate the SSL certificate.
+
+``pagerduty_ignore_ssl_errors``: By default ElastAlert 2 will verify SSL certificate. Set this option to ``True`` if you want to ignore SSL errors.
+
 V2 API Options (Optional):
 
 These options are specific to the PagerDuty V2 API

--- a/elastalert/alerters/pagerduty.py
+++ b/elastalert/alerters/pagerduty.py
@@ -18,6 +18,8 @@ class PagerDutyAlerter(Alerter):
         self.pagerduty_incident_key_args = self.rule.get('pagerduty_incident_key_args', None)
         self.pagerduty_event_type = self.rule.get('pagerduty_event_type', 'trigger')
         self.pagerduty_proxy = self.rule.get('pagerduty_proxy', None)
+        self.pagerduty_ca_certs = self.rule.get('pagerduty_ca_certs')
+        self.pagerduty_ignore_ssl_errors = self.rule.get('pagerduty_ignore_ssl_errors', False)
 
         self.pagerduty_api_version = self.rule.get('pagerduty_api_version', 'v1')
         self.pagerduty_v2_payload_class = self.rule.get('pagerduty_v2_payload_class', '')
@@ -90,12 +92,20 @@ class PagerDutyAlerter(Alerter):
 
         # set https proxy, if it was provided
         proxies = {'https': self.pagerduty_proxy} if self.pagerduty_proxy else None
+        if self.pagerduty_ca_certs:
+            verify = self.pagerduty_ca_certs
+        else:
+            verify = not self.pagerduty_ignore_ssl_errors
+
+        if self.pagerduty_ignore_ssl_errors:
+            requests.packages.urllib3.disable_warnings()
         try:
             response = requests.post(
                 self.url,
                 data=json.dumps(payload, cls=DateTimeEncoder, ensure_ascii=False).encode("utf-8"),
                 headers=headers,
-                proxies=proxies
+                proxies=proxies,
+                verify=verify
             )
             response.raise_for_status()
         except RequestException as e:

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -670,6 +670,8 @@ properties:
   pagerduty_incident_key: {type: string}
   pagerduty_incident_key_args: {type: array, items: {type: string}}
   pagerduty_proxy: {type: string}
+  pagerduty_ca_certs: {type: [boolean, string]}
+  pagerduty_ignore_ssl_errors: {type: boolean}
   pagerduty_api_version: {type: string, enum: ['v1', 'v2']}
   pagerduty_v2_payload_class: {type: string}
   pagerduty_v2_payload_class_args: {type: array, items: {type: string}}

--- a/tests/alerters/alertmanager_test.py
+++ b/tests/alerters/alertmanager_test.py
@@ -188,7 +188,7 @@ def test_alertmanager_timeout():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('',   '',     True),
     ('',   True,   False),
     ('',   False,  True),
@@ -199,7 +199,7 @@ def test_alertmanager_timeout():
     (False, True,  False),
     (False, False, True)
 ])
-def test_alertmanager_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_alertmanager_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test Alertmanager Rule',
         'type': 'any',
@@ -255,7 +255,7 @@ def test_alertmanager_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         data=mock.ANY,
         headers={'content-type': 'application/json'},
         proxies=None,
-        verify=excpet_verify,
+        verify=expect_verify,
         timeout=10,
         auth=None
     )

--- a/tests/alerters/debug_test.py
+++ b/tests/alerters/debug_test.py
@@ -39,12 +39,12 @@ def test_debug_alerter(caplog):
     }
     alert.alert([match])
 
-    excepted1 = 'Alert for Test Debug Event Alerter at None:'
-    assert ('elastalert', logging.INFO, excepted1) == caplog.record_tuples[0]
+    expected1 = 'Alert for Test Debug Event Alerter at None:'
+    assert ('elastalert', logging.INFO, expected1) == caplog.record_tuples[0]
 
-    excepted2 = 'Test Debug Event Alerter\n\n@timestamp: 2021-01-01T00:00:00\n'
-    excepted2 += 'name: debug-test-name\n'
-    assert ('elastalert', logging.INFO, excepted2) == caplog.record_tuples[1]
+    expected2 = 'Test Debug Event Alerter\n\n@timestamp: 2021-01-01T00:00:00\n'
+    expected2 += 'name: debug-test-name\n'
+    assert ('elastalert', logging.INFO, expected2) == caplog.record_tuples[1]
 
 
 def test_debug_alerter_querykey(caplog):
@@ -66,9 +66,9 @@ def test_debug_alerter_querykey(caplog):
     }
     alert.alert([match])
 
-    excepted1 = 'Alert for Test Debug Event Alerter, aProbe at None:'
-    assert ('elastalert', logging.INFO, excepted1) == caplog.record_tuples[0]
+    expected1 = 'Alert for Test Debug Event Alerter, aProbe at None:'
+    assert ('elastalert', logging.INFO, expected1) == caplog.record_tuples[0]
 
-    excepted2 = 'Test Debug Event Alerter\n\n@timestamp: 2021-01-01T00:00:00\n'
-    excepted2 += 'hostname: aProbe\nname: debug-test-name\n'
-    assert ('elastalert', logging.INFO, excepted2) == caplog.record_tuples[1]
+    expected2 = 'Test Debug Event Alerter\n\n@timestamp: 2021-01-01T00:00:00\n'
+    expected2 += 'hostname: aProbe\nname: debug-test-name\n'
+    assert ('elastalert', logging.INFO, expected2) == caplog.record_tuples[1]

--- a/tests/alerters/httppost2_test.py
+++ b/tests/alerters/httppost2_test.py
@@ -1886,7 +1886,7 @@ def test_http_alerter_headers():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('', '', True),
     ('', True, False),
     ('', False, True),
@@ -1897,7 +1897,7 @@ def test_http_alerter_headers():
     (False, True, False),
     (False, False, True)
 ])
-def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test HTTP Post Alerter Without Payload',
         'type': 'any',
@@ -1929,7 +1929,7 @@ def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
         proxies=None,
         timeout=10,
-        verify=excpet_verify
+        verify=expect_verify
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 

--- a/tests/alerters/httppost_test.py
+++ b/tests/alerters/httppost_test.py
@@ -217,7 +217,7 @@ def test_http_alerter_headers():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('',    '',    True),
     ('',    True,  False),
     ('',    False, True),
@@ -228,7 +228,7 @@ def test_http_alerter_headers():
     (False, True,  False),
     (False, False, True)
 ])
-def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test HTTP Post Alerter Without Payload',
         'type': 'any',
@@ -262,7 +262,7 @@ def test_http_alerter_post_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
         proxies=None,
         timeout=10,
-        verify=excpet_verify
+        verify=expect_verify
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1036,8 +1036,8 @@ def test_opsgenie_parse_responders(caplog):
             match,
             rule['opsgenie_default_teams']
         )
-    excepted = ['Test']
-    assert excepted == actual
+    expected = ['Test']
+    assert expected == actual
     user, level, message = caplog.record_tuples[0]
     assert logging.WARNING == level
     assert "Cannot create responder for OpsGenie Alert. Key not foud: 'RECEIPIENT_PREFIX'." in message
@@ -1081,8 +1081,8 @@ def test_opsgenie_create_custom_title():
     ]
     alert = OpsGenieAlerter(rule)
     actual = alert.create_custom_title(match)
-    excepted = 'abc Testing 2014-10-31T00:00:00'
-    assert excepted == actual
+    expected = 'abc Testing 2014-10-31T00:00:00'
+    assert expected == actual
 
 
 def test_opsgenie_create_custom_description():
@@ -1159,8 +1159,8 @@ def test_opsgenie_get_details():
     ]
     alert = OpsGenieAlerter(rule)
     actual = alert.get_details(match)
-    excepted = {'Message': 'Testing', 'abc': 'test'}
-    assert excepted == actual
+    expected = {'Message': 'Testing', 'abc': 'test'}
+    assert expected == actual
 
 
 def test_opsgenie_get_details2():
@@ -1185,5 +1185,5 @@ def test_opsgenie_get_details2():
     ]
     alert = OpsGenieAlerter(rule)
     actual = alert.get_details(match)
-    excepted = {}
-    assert excepted == actual
+    expected = {}
+    assert expected == actual

--- a/tests/alerters/pagerduty_test.py
+++ b/tests/alerters/pagerduty_test.py
@@ -734,13 +734,13 @@ def test_pagerduty_required_error(pagerduty_service_key, pagerduty_client_name, 
         assert expected_data in str(ea)
 
 
-@pytest.mark.parametrize('pagerduty_event_type, excepted_pagerduty_event_type, excepted_log_message', [
+@pytest.mark.parametrize('pagerduty_event_type, expected_pagerduty_event_type, expected_log_message', [
     ('',            'trigger',     'Trigger sent to PagerDuty'),
     ('trigger',     'trigger',     'Trigger sent to PagerDuty'),
     ('resolve',     'resolve',     'Resolve sent to PagerDuty'),
     ('acknowledge', 'acknowledge', 'acknowledge sent to PagerDuty')
 ])
-def test_pagerduty_alerter_event_type(pagerduty_event_type, excepted_pagerduty_event_type, excepted_log_message, caplog):
+def test_pagerduty_alerter_event_type(pagerduty_event_type, expected_pagerduty_event_type, expected_log_message, caplog):
     caplog.set_level(logging.INFO)
     rule = {
         'name': 'Test PD Rule',
@@ -768,14 +768,14 @@ def test_pagerduty_alerter_event_type(pagerduty_event_type, excepted_pagerduty_e
         'details': {
             'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: foobarbaz\n'
         },
-        'event_type': excepted_pagerduty_event_type,
+        'event_type': expected_pagerduty_event_type,
         'incident_key': '',
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
                                               data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
-    assert ('elastalert', logging.INFO, excepted_log_message) == caplog.record_tuples[0]
+    assert ('elastalert', logging.INFO, expected_log_message) == caplog.record_tuples[0]
 
 
 def test_pagerduty_alerter_match_timestamp_none():

--- a/tests/alerters/pagerduty_test.py
+++ b/tests/alerters/pagerduty_test.py
@@ -39,7 +39,7 @@ def test_pagerduty_alerter():
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -85,7 +85,7 @@ def test_pagerduty_alerter_v2():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -132,7 +132,7 @@ def test_pagerduty_alerter_v2_payload_class_args():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -179,7 +179,7 @@ def test_pagerduty_alerter_v2_payload_component_args():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -226,7 +226,7 @@ def test_pagerduty_alerter_v2_payload_group_args():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -273,7 +273,7 @@ def test_pagerduty_alerter_v2_payload_source_args():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -322,7 +322,7 @@ def test_pagerduty_alerter_v2_payload_custom_details():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -367,7 +367,7 @@ def test_pagerduty_alerter_v2_payload_include_all_info():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -399,7 +399,7 @@ def test_pagerduty_alerter_custom_incident_key():
         'incident_key': 'custom key',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -432,7 +432,7 @@ def test_pagerduty_alerter_custom_incident_key_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -466,7 +466,7 @@ def test_pagerduty_alerter_custom_alert_subject():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -502,7 +502,7 @@ def test_pagerduty_alerter_custom_alert_subject_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -539,7 +539,7 @@ def test_pagerduty_alerter_custom_alert_subject_with_args_specifying_trigger():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -578,7 +578,7 @@ def test_pagerduty_alerter_proxy():
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
-                                              proxies={'https': 'http://proxy.url'})
+                                              proxies={'https': 'http://proxy.url'}, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -676,7 +676,7 @@ def test_pagerduty_alerter_v2_payload_severity(severity, except_severity):
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -773,7 +773,7 @@ def test_pagerduty_alerter_event_type(pagerduty_event_type, excepted_pagerduty_e
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
     assert ('elastalert', logging.INFO, excepted_log_message) == caplog.record_tuples[0]
 
@@ -812,7 +812,7 @@ def test_pagerduty_alerter_match_timestamp_none():
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
-                                              proxies={'https': 'http://proxy.url'})
+                                              proxies={'https': 'http://proxy.url'}, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -856,5 +856,53 @@ def test_pagerduty_alerter_v2_match_timestamp_none():
         'routing_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/v2/enqueue',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
+    ('',    '',    True),
+    ('',    True,  False),
+    ('',    False, True),
+    (True,  '',    True),
+    (True,  True,  True),
+    (True,  False, True),
+    (False, '',    True),
+    (False, True,  False),
+    (False, False, True)
+])
+def test_pagerduty_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
+    rule = {
+        'name': 'Test PD Rule',
+        'type': 'any',
+        'pagerduty_service_key': 'magicalbadgers',
+        'pagerduty_client_name': 'ponies inc.',
+        'alert': []
+    }
+    if ca_certs:
+        rule['pagerduty_ca_certs'] = ca_certs
+
+    if ignore_ssl_errors:
+        rule['pagerduty_ignore_ssl_errors'] = ignore_ssl_errors
+
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = PagerDutyAlerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'client': 'ponies inc.',
+        'description': 'Test PD Rule',
+        'details': {
+            'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: foobarbaz\n'
+        },
+        'event_type': 'trigger',
+        'incident_key': '',
+        'service_key': 'magicalbadgers',
+    }
+    mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
+                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=expect_verify)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])

--- a/tests/alerters/pagerduty_test.py
+++ b/tests/alerters/pagerduty_test.py
@@ -399,7 +399,8 @@ def test_pagerduty_alerter_custom_incident_key():
         'incident_key': 'custom key',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -432,7 +433,8 @@ def test_pagerduty_alerter_custom_incident_key_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -466,7 +468,8 @@ def test_pagerduty_alerter_custom_alert_subject():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -502,7 +505,8 @@ def test_pagerduty_alerter_custom_alert_subject_with_args():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -539,7 +543,8 @@ def test_pagerduty_alerter_custom_alert_subject_with_args_specifying_trigger():
         'incident_key': 'custom foobarbaz',
         'service_key': 'magicalbadgers',
     }
-    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
@@ -859,6 +864,7 @@ def test_pagerduty_alerter_v2_match_timestamp_none():
                                               data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=True)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
+
 @pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('',    '',    True),
     ('',    True,  False),
@@ -904,5 +910,6 @@ def test_pagerduty_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
         'service_key': 'magicalbadgers',
     }
     mock_post_request.assert_called_once_with('https://events.pagerduty.com/generic/2010-04-15/create_event.json',
-                                              data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None, verify=expect_verify)
+                                              data=mock.ANY, headers={'content-type': 'application/json'},
+                                              proxies=None, verify=expect_verify)
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])

--- a/tests/alerters/rocketchat_test.py
+++ b/tests/alerters/rocketchat_test.py
@@ -1067,7 +1067,7 @@ def test_rocket_chat_opensearch_discover_color():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('', '', True),
     ('', True, False),
     ('', False, True),
@@ -1078,7 +1078,7 @@ def test_rocket_chat_opensearch_discover_color():
     (False, True, False),
     (False, False, True)
 ])
-def test_rocket_chat_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_rocket_chat_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test Rule',
         'type': 'any',
@@ -1121,7 +1121,7 @@ def test_rocket_chat_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         data=mock.ANY,
         headers={'content-type': 'application/json'},
         proxies=None,
-        verify=excpet_verify,
+        verify=expect_verify,
         timeout=10
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])

--- a/tests/alerters/servicenow_test.py
+++ b/tests/alerters/servicenow_test.py
@@ -212,21 +212,21 @@ def test_servicenow_getinfo():
 
 servicenow_required_error_param = 'username, password, servicenow_rest_url, short_description, comments, '
 servicenow_required_error_param += 'assignment_group, category, subcategory, cmdb_ci, caller_id, expected_data'
-servicenow_required_error_excepted = 'username, password, servicenow_rest_url, short_description, comments, '
-servicenow_required_error_excepted += 'assignment_group, category, subcategory, cmdb_ci, caller_id'
+servicenow_required_error_expected = 'username, password, servicenow_rest_url, short_description, comments, '
+servicenow_required_error_expected += 'assignment_group, category, subcategory, cmdb_ci, caller_id'
 
 
 @pytest.mark.parametrize(servicenow_required_error_param, [
-    ('',  '',  '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', '',  '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', 'e', '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', 'e', 'f', ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', 'e', 'f', 'g' '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', 'e', 'f', 'g' 'h', '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
-    ('a', 'b', 'c', 'd', 'e', 'f', 'g' 'h', 'i', '',  '', 'Missing required option(s): ' + servicenow_required_error_excepted),
+    ('',  '',  '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', '',  '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', '',  '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', '',  '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', '',  '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', 'e', '',  ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', 'e', 'f', ''  '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', 'e', 'f', 'g' '',  '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', 'e', 'f', 'g' 'h', '',  '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
+    ('a', 'b', 'c', 'd', 'e', 'f', 'g' 'h', 'i', '',  '', 'Missing required option(s): ' + servicenow_required_error_expected),
     ('a', 'b', 'c', 'd', 'e', 'f', 'g' 'h', 'i', 'j', 'k',
         {
             "type": "ServiceNow",

--- a/tests/alerters/slack_test.py
+++ b/tests/alerters/slack_test.py
@@ -1110,7 +1110,7 @@ def test_slack_alert_fields():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('', '', True),
     ('', True, False),
     ('', False, True),
@@ -1121,7 +1121,7 @@ def test_slack_alert_fields():
     (False, True, False),
     (False, False, True)
 ])
-def test_slack_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_slack_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test Rule',
         'type': 'any',
@@ -1166,7 +1166,7 @@ def test_slack_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         data=mock.ANY,
         headers={'content-type': 'application/json'},
         proxies=None,
-        verify=excpet_verify,
+        verify=expect_verify,
         timeout=10
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])

--- a/tests/alerters/teams_test.py
+++ b/tests/alerters/teams_test.py
@@ -200,7 +200,7 @@ def test_ms_teams_required_error(ms_teams_webhook_url, expected_data):
         assert expected_data in str(ea)
 
 
-@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, excpet_verify', [
+@pytest.mark.parametrize('ca_certs, ignore_ssl_errors, expect_verify', [
     ('',    '',    True),
     ('',    True,  False),
     ('',    False, True),
@@ -211,7 +211,7 @@ def test_ms_teams_required_error(ms_teams_webhook_url, expected_data):
     (False, True,  False),
     (False, False, True)
 ])
-def test_ms_teams_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
+def test_ms_teams_ca_certs(ca_certs, ignore_ssl_errors, expect_verify):
     rule = {
         'name': 'Test Rule',
         'type': 'any',
@@ -247,7 +247,7 @@ def test_ms_teams_ca_certs(ca_certs, ignore_ssl_errors, excpet_verify):
         data=mock.ANY,
         headers={'content-type': 'application/json'},
         proxies=None,
-        verify=excpet_verify
+        verify=expect_verify
     )
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 

--- a/tests/alerters/tencentsms_test.py
+++ b/tests/alerters/tencentsms_test.py
@@ -24,12 +24,12 @@ def test_tencentsms_get_info():
     rules_loader.load_modules(rule)
     alert = TencentSMSAlerter(rule)
 
-    excepted = {
+    expected = {
         'type': 'tencent sms',
         'to_number': ["+8613711112222"]
     }
     actual = alert.get_info()
-    assert excepted == actual
+    assert expected == actual
 
 
 @pytest.mark.parametrize('tencent_sms_template_parm, expected_data', [

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1387,9 +1387,9 @@ def test_add_aggregated_alert_error(ea, caplog):
     with mock.patch('elastalert.elastalert.elasticsearch_client'):
         ea.run_rule(ea.rules[0], END, START)
         user, level, message = caplog.record_tuples[0]
-        exceptd = "[add_aggregated_alert]"
-        exceptd += "Error parsing aggregate send time format unsupported operand type(s) for +: 'datetime.datetime' and 'dict'"
-        assert exceptd in message
+        expected_data = "[add_aggregated_alert]"
+        expected_data += "Error parsing aggregate send time format unsupported operand type(s) for +: 'datetime.datetime' and 'dict'"
+        assert expected_data in message
 
 
 def test_get_elasticsearch_client_same_rule(ea):
@@ -1426,8 +1426,8 @@ def test_time_enhancement(ea):
         'somefield': 'foobarbaz'
     }
     te.process(match)
-    excepted = '2021-01-01 00:00 UTC'
-    assert match['@timestamp'] == excepted
+    expected_data = '2021-01-01 00:00 UTC'
+    assert match['@timestamp'] == expected_data
 
 
 def test_get_kibana_discover_external_url_formatter_same_rule(ea):


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->
- Add pagerduty_ca_certs option to allow specifying a cert bundle for SSL certificate validation
- Add pagerduty_ignore_ssl_errors option
- Fix typos

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
