### PR TITLE
Allow dynamic severity for TheHive alerter

### DIFF
--- a/elastalert/alerters/thehive.py
+++ b/elastalert/alerters/thehive.py
@@ -97,14 +97,6 @@ class HiveAlerter(Alerter):
         else:
             return raw
 
-    def assign_custom_severity(self, match: dict, severity_field: str) -> int:
-        severity_value = self.lookup_field(match, severity_field, 1)
-        for severity_scale in self.rule.get("severity_scale"):
-            if severity_scale["min"] <= severity_value <= severity_scale["max"]:
-                return severity_scale["severity"]
-        # Fallback to lowest severity
-        return 1
-
     def alert(self, matches):
         # Build TheHive alert object, starting with some defaults, updating with any
         # user-specified config
@@ -126,9 +118,9 @@ class HiveAlerter(Alerter):
             artifacts = artifacts + self.load_observable_artifacts(match)
             tags.update(self.load_tags(alert_config['tags'], match))
 
-            # Allow a custom severity scale
-            if (severity := alert_config.get("severity")) not in (1, 2, 3, 4):
-                alert_config['severity'] = self.assign_custom_severity(match, severity)
+            # Check for a dynamic severity
+            if (severity_field := alert_config.get("severity")) not in (1, 2, 3, 4):
+                alert_config['severity'] = self.lookup_field(match, severity_field, 1)
 
         alert_config['artifacts'] = artifacts
         alert_config['tags'] = list(tags)


### PR DESCRIPTION
## Description

A rule for TheHive can currently only set a static severity with possible values being {1, 2, 3, 4}. The alerts in my project are highly dynamic with a severity scale ranging from 0-100. I added an option to the config that allows to specify a custom severity scale, given a severity field in the match. The new config options look as follows:

```
hive_alert_config:
  severity: 'alert.severity'

# Add custom severity scale
severity_scale:
  - severity: 1
    min: 0
    max: 24
  - severity: 2
    min: 25
    max: 49
  - severity: 3
    min: 50
    max: 74
  - severity: 4
    min: 75
    max: 100
```

This would not break older configurations as these are still valid.

Let me know if this seems like a valid contribution. In this case, I will write some tests and update the documentation. if not, feel free to reject. 

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
