### PR TITLE
Bugfix/opsgenie alerter handle keyerror in custom message

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -2,30 +2,20 @@ name: publish_image
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
+    # Publish `bugfix/opsgenie-alerter-handle-keyerror-in-custom-message` as Docker image.
     branches:
-      - master
-
-    tags:
-      - 2.*
+      - bugfix/opsgenie-alerter-handle-keyerror-in-custom-message
 
 env:
   IMAGE_NAME: elastalert2
-  DOCKER_REPO: jertel/elastalert2
+  DOCKER_REPO: facilityworld/elastalert2
 
 jobs:
   push:
-    if: github.repository_owner == 'jertel'
-    
-    environment: Main
-    
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Log into GitHub Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Log into Docker Registry
         run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -41,48 +31,27 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          TAG2=""
-          if [[ "$VERSION" == "2."* ]]; then
-            TAG2="--tag $DOCKER_REPO:2"
-          fi
-
           echo VERSION=$VERSION
-          echo TAG2=$TAG2
 
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker buildx build \
           --platform=linux/amd64,linux/arm64 \
           --output "type=image,push=true" \
           --file ./Dockerfile . \
-          --tag $DOCKER_REPO:$VERSION $TAG2
+          --tag $DOCKER_REPO:$VERSION
 
-      - name: Build and push image to GitHub
-        run: |
-          docker build . --file Dockerfile --tag $IMAGE_NAME
+      # - name: Build and push image to GitHub
+      #   run: |
+      #     docker build . --file Dockerfile --tag $IMAGE_NAME
 
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+      #     IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
 
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+      #     # Change all uppercase to lowercase
+      #     IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+      #     echo IMAGE_ID=$IMAGE_ID
+      #     echo VERSION=$VERSION
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          # Push to GitHub Package
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
-
-          if [[ "$VERSION" == "2."* ]]; then
-            # Push to GitHub Package
-            docker tag $IMAGE_NAME $IMAGE_ID:2
-            docker push $IMAGE_ID:2
-          fi
+      #     # Push to GitHub Package
+      #     docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+      #     docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -40,6 +40,7 @@ jobs:
           --file ./Dockerfile . \
           --tag $DOCKER_REPO:$VERSION
 
+      #
       # - name: Build and push image to GitHub
       #   run: |
       #     docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -40,7 +40,6 @@ jobs:
           --file ./Dockerfile . \
           --tag $DOCKER_REPO:$VERSION
 
-      #
       # - name: Build and push image to GitHub
       #   run: |
       #     docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -2,20 +2,30 @@ name: publish_image
 
 on:
   push:
-    # Publish `bugfix/opsgenie-alerter-handle-keyerror-in-custom-message` as Docker image.
+    # Publish `master` as Docker `latest` image.
     branches:
-      - bugfix/opsgenie-alerter-handle-keyerror-in-custom-message
+      - master
+
+    tags:
+      - 2.*
 
 env:
   IMAGE_NAME: elastalert2
-  DOCKER_REPO: facilityworld/elastalert2
+  DOCKER_REPO: jertel/elastalert2
 
 jobs:
   push:
+    if: github.repository_owner == 'jertel'
+    
+    environment: Main
+    
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Log into GitHub Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Log into Docker Registry
         run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -31,27 +41,48 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          TAG2=""
+          if [[ "$VERSION" == "2."* ]]; then
+            TAG2="--tag $DOCKER_REPO:2"
+          fi
+
           echo VERSION=$VERSION
+          echo TAG2=$TAG2
 
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           docker buildx build \
           --platform=linux/amd64,linux/arm64 \
           --output "type=image,push=true" \
           --file ./Dockerfile . \
-          --tag $DOCKER_REPO:$VERSION
+          --tag $DOCKER_REPO:$VERSION $TAG2
 
-      # - name: Build and push image to GitHub
-      #   run: |
-      #     docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Build and push image to GitHub
+        run: |
+          docker build . --file Dockerfile --tag $IMAGE_NAME
 
-      #     IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
 
-      #     # Change all uppercase to lowercase
-      #     IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 
-      #     echo IMAGE_ID=$IMAGE_ID
-      #     echo VERSION=$VERSION
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-      #     # Push to GitHub Package
-      #     docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-      #     docker push $IMAGE_ID:$VERSION
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          # Push to GitHub Package
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
+          if [[ "$VERSION" == "2."* ]]; then
+            # Push to GitHub Package
+            docker tag $IMAGE_NAME $IMAGE_ID:2
+            docker push $IMAGE_ID:2
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Docs] Fixed typo in Alerta docs with incorrect number of seconds in a day. - @jertel
 - Update GitHub actions to avoid running publish workflows on forked branches. - @jertel
 - Rewrite `_find_es_dict_by_key` per [discussion #1450](https://github.com/jertel/elastalert2/discussions/1450) for fieldnames literally ending in `.keyword` [#1459](https://github.com/jertel/elastalert2/pull/1459) - @jmacdone @jertel
+- [Opsgenie] Fix KeyError handling in OpsGenieAlerter custom message formatting to provide a default fallback message if a key is missing. - @mrsymlove
 
 # 2.18.0
 

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -64,15 +64,15 @@ class OpsGenieAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
 
-    if self.custom_message is None:
-        self.message = self.create_title(matches)
-    else:
-        # Safely get values from matches[0] with a default fallback
-        try:
-            self.message = self.custom_message.format(**matches[0])
-        except KeyError as e:
-            missing_key = str(e)
-            self.message = f"Key {missing_key} is missing in the alert data"
+        if self.custom_message is None:
+            self.message = self.create_title(matches)
+        else:
+            # Safely get values from matches[0] with a default fallback
+            try:
+                self.message = self.custom_message.format(**matches[0])
+            except KeyError as e:
+                missing_key = str(e)
+                self.message = f"Key {missing_key} is missing in the alert data"
 
         self.recipients = self._parse_responders(self.recipients, self.recipients_args, matches, self.default_reciepients)
         self.teams = self._parse_responders(self.teams, self.teams_args, matches, self.default_teams)

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -64,10 +64,16 @@ class OpsGenieAlerter(Alerter):
             if len(matches) > 1:
                 body += '\n----------------------------------------\n'
 
-        if self.custom_message is None:
-            self.message = self.create_title(matches)
-        else:
+    if self.custom_message is None:
+        self.message = self.create_title(matches)
+    else:
+        # Safely get values from matches[0] with a default fallback
+        try:
             self.message = self.custom_message.format(**matches[0])
+        except KeyError as e:
+            missing_key = str(e)
+            self.message = f"Key {missing_key} is missing in the alert data"
+
         self.recipients = self._parse_responders(self.recipients, self.recipients_args, matches, self.default_reciepients)
         self.teams = self._parse_responders(self.teams, self.teams_args, matches, self.default_teams)
         post = {}


### PR DESCRIPTION
## Description

This PR addresses a bug related to the handling of KeyError when formatting custom messages in the OpsGenieAlerter class. The change ensures that the alert message does not cause a failure if a key is missing by providing a default fallback message.

### Bug Details

- **Issue:** KeyError when formatting custom messages
- **File Affected:** `opsgenie.py`
- **Change Description:**
  - Added a try-except block to catch KeyError
  - Provided a default fallback message indicating the missing key

### ElastAlert2 Logs

```
2024-06-06T11:57:26.558778913Z ERROR:elastalert
(most recent call last):
2024-06-06T11:57:26.558807924Z File "/usr/local/lib/python3.12/site-packages/elastalert/elastalert.py", line 1324, in alert
2024-06-06T11:57:26.558811232Z return self.send_alert(matches, rule, alert_time=alert_time, retried=retried)
2024-06-06T11:57:26.558814067Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-06T11:57:26.558816392Z File "/usr/local/lib/python3.12/site-packages/elastalert/elastalert.py", line 1409, in send_alert
2024-06-06T11:57:26.558818728Z alert.alert(matches)
2024-06-06T11:57:26.558820932Z File "/usr/local/lib/python3.12/site-packages/elastalert/alerters/opsgenie.py", line 70, in alert
2024-06-06T11:57:26.558823318Z self.message = self.custom_message.format(**matches[0])
2024-06-06T11:57:26.558825477Z ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-06T11:57:26.558827645Z KeyError: 'stack_trace'
2024-06-06T11:57:26.558829715Z
2024-06-06T11:57:26.558832096Z ERROR:elastalert
exception running rule LIVE ERROR ALARM: 'stack_trace'
```

### Opsgenie Rule Snippet

```yaml
opsgenie_message: "LIVE ERROR:{app_name}:{message:.50}:{stack_trace:.70}"
opsgenie_priority: "P1"
opsgenie_alias: "{app_name}-{message:.50}-{stack_trace:.70}"
```

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Update of the documentation is not needed since it is only a bugfix.

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
