### PR TITLE
Fix Numpy version before 2.0.0 that breaks Elasticsearch-py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Docs] Fixed typo in Alerta docs with incorrect number of seconds in a day. - @jertel
 - Update GitHub actions to avoid running publish workflows on forked branches. - @jertel
 - Rewrite `_find_es_dict_by_key` per [discussion #1450](https://github.com/jertel/elastalert2/discussions/1450) for fieldnames literally ending in `.keyword` [#1459](https://github.com/jertel/elastalert2/pull/1459) - @jmacdone @jertel
+- Fix numpy before 2.0.0 that [breaks elasticsearch-py](https://github.com/jertel/elastalert2/discussions/1470) - [#]() - @gregorywychowaniec-zt
 
 # 2.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [Docs] Fixed typo in Alerta docs with incorrect number of seconds in a day. - @jertel
 - Update GitHub actions to avoid running publish workflows on forked branches. - @jertel
 - Rewrite `_find_es_dict_by_key` per [discussion #1450](https://github.com/jertel/elastalert2/discussions/1450) for fieldnames literally ending in `.keyword` [#1459](https://github.com/jertel/elastalert2/pull/1459) - @jmacdone @jertel
-- Fix numpy before 2.0.0 that [breaks elasticsearch-py](https://github.com/jertel/elastalert2/discussions/1470) - [#]() - @gregorywychowaniec-zt
+- Fix numpy before 2.0.0 that [breaks elasticsearch-py](https://github.com/jertel/elastalert2/discussions/1470) - [#1472](https://github.com/jertel/elastalert2/pull/1472) - @gregorywychowaniec-zt
 
 # 2.18.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aws-requests-auth>=0.4.3
 boto3>=1.34.54
 cffi>=1.16.0
 croniter>=2.0.2
+numpy<2.0.0
 elasticsearch==7.10.1
 envparse>=0.2.0
 exotel==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'boto3>=1.34.54',
         'cffi>=1.16.0',
         'croniter>=2.0.2',
+        'numpy<2.0.0',
         'elasticsearch==7.10.1',
         'envparse>=0.2.0',
         'exotel==0.1.5',


### PR DESCRIPTION
## Description

The last major upgrade of Numpy used by Elasticsearch-py generates errors, see #1470. This PR fix the Numpy's version.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I set Numpy with `<2.0.0` to include future security updates. We can also set `==1.26.4` if there's a risk I haven't taken into consideration.