### PR TITLE
fixed fields types error on instance indexer_alert_config  in schema.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - TBD
 
 ## Other changes
+- [indexer] fixed fields types error on instance indexer_alert_config in schema.yml
 - TBD
 
 # 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- [indexer] fixed fields types error on instance indexer_alert_config in schema.yml
+- [indexer] fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
 - TBD
 
 # 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - TBD
 
 ## Other changes
-- fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
+- [Indexer] Fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
 
 # 2.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 - TBD
 
 ## Other changes
-- [indexer] fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
-- TBD
+- fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
 
 # 2.19.0
 

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -562,11 +562,16 @@ properties:
       "^.+$":
         oneOf:
           - type: [boolean, string, integer]
+          - type: array
+            items:
+                type: object
+                properties:
+                  name: { type: string , minLength: 1 }
+                  value: { type: [boolean, string, integer] , minLength: 1 }
+                  "^.+$": { type: [boolean, string, integer], minLength: 1 }
           - type: object
-            additionalProperties: false
-            required: [ field ]
             properties:
-              field: { type: [boolean, string, integer], minLength: 1 }
+              "^.+$": { type: [boolean, string, integer], minLength: 1 }
 
   ### IRIS
   iris_host: {type: string}


### PR DESCRIPTION
## Description
Hi, I saw that I made some mistakes when adding field types to the schema.yml.
I fixed and tested it.


Now it works well 
```
  indexer_alert_config:
    type: object
    minProperties: 1
    patternProperties:
      "^.+$":
        oneOf:
          - type: [boolean, string, integer]
          - type: array
            items:
                type: object
                properties:
                  name: { type: string , minLength: 1 }
                  value: { type: [boolean, string, integer] , minLength: 1 }
                  "^.+$": { type: [boolean, string, integer], minLength: 1 }
          - type: object
            properties:
              "^.+$": { type: [boolean, string, integer], minLength: 1 }
```
```
indexer_alert_config:

  rule:
    - name: true (boolean type)
      value: name
    - name: index
      value: index
    - name: query
      value: filter

```
![image](https://github.com/user-attachments/assets/dc30f92c-24f3-47e1-9c74-97518857e394)

```
indexer_alert_config:

  rule:
    - name: name (string type)
      value: name
    - name: index
      value: index
    - name: query
      value: filter
```
![image](https://github.com/user-attachments/assets/1f806416-303e-4a25-ba17-b13c849b91c1)

Sorry about that 

## Checklist


- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [  ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [  ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

