### PR TITLE
[Powerautomate] Add size text sumary and body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - TBD
 
 ## New features
-- [MS Power Automate] New Alert Channel with Microsoft Power Automate - [#1505](https://github.com/jertel/elastalert2/pull/1505) - @marssilva
+- [MS Power Automate] New Alert Channel with Microsoft Power Automate - [#1505](https://github.com/jertel/elastalert2/pull/1505)  [#1513](https://github.com/jertel/elastalert2/pull/1513) - @marssilva
 
 ## Other changes
 - [Indexer] Fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1642,6 +1642,10 @@ The alerter requires the following options:
 
 Optional:
 
+``ms_power_automate_summary_text_size``: By default, it is set to the value ``large``. This field supports the values, default, small, medium and extraLarge.
+
+``ms_power_automate_body_text_size``: By default, this field is not set, and has the default behavior in MS Power Automate. This field supports the values, default, small, medium, large and extraLarge.
+
 ``ms_power_automate_alert_summary``: Microsoft Power Automate use this value for notification title, defaults to `alert_subject <https://elastalert2.readthedocs.io/en/latest/alerts.html#alert-subject>`_. You can set this value with arbitrary text if you don't want to use the default.
 
 ``ms_power_automate_kibana_discover_color``: By default, the alert will be published with the ``default`` type blue if not specified. If set to ``positive``, action is displayed with a positive style (typically the button becomes accent color), If set to ``destructive``, Action is displayed with a destructive style (typically the button becomes red)

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1642,7 +1642,7 @@ The alerter requires the following options:
 
 Optional:
 
-``ms_power_automate_summary_text_size``: By default, it is set to the value ``large``. This field supports the values, default, small, medium and extraLarge.
+``ms_power_automate_summary_text_size``: By default, is set to the value ``large``. This field supports the values, default, small, medium and extraLarge.
 
 ``ms_power_automate_body_text_size``: By default, this field is not set, and has the default behavior in MS Power Automate. This field supports the values, default, small, medium, large and extraLarge.
 

--- a/elastalert/alerters/powerautomate.py
+++ b/elastalert/alerters/powerautomate.py
@@ -18,6 +18,8 @@ class MsPowerAutomateAlerter(Alerter):
             self.ms_power_automate_webhook_url = [self.ms_power_automate_webhook_url]
         self.ms_power_automate_proxy = self.rule.get('ms_power_automate_proxy', None)
         self.ms_power_automate_alert_summary = self.rule.get('ms_power_automate_alert_summary', None)
+        self.ms_power_automate_summary_text_size = self.rule.get('ms_power_automate_summary_text_size', 'large')
+        self.ms_power_automate_body_text_size = self.rule.get('ms_power_automate_body_text_size', '')
         self.ms_power_automate_kibana_discover_color = self.rule.get('ms_power_automate_kibana_discover_color', 'default')
         self.ms_power_automate_ca_certs = self.rule.get('ms_power_automate_ca_certs')
         self.ms_power_automate_ignore_ssl_errors = self.rule.get('ms_power_automate_ignore_ssl_errors', False)
@@ -68,7 +70,8 @@ class MsPowerAutomateAlerter(Alerter):
                                 "type": "TextBlock",
                                 "text": summary,
                                 "weight": "Bolder",
-                                "size": "ExtraLarge",
+                                "wrap": True,
+                                "size": self.ms_power_automate_summary_text_size
                             },
                             {
                                 "type": "TextBlock",
@@ -82,6 +85,9 @@ class MsPowerAutomateAlerter(Alerter):
                 }
             ]
         }
+
+        if self.ms_power_automate_body_text_size != '':
+            payload['attachments'][0]['content']['body'][1]['size'] = self.ms_power_automate_body_text_size
 
         if self.ms_power_automate_teams_card_width_full:
             payload['attachments'][0]['content']['msteams'] = {

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -688,8 +688,8 @@ properties:
   ### Microsoft Power Automate
   ms_power_automate_webhook_url: *arrayOfString
   ms_power_automate_alert_summary: {type: string}
-  ms_power_automate_summary_text_size: {type: string}
-  ms_power_automate_body_text_size: {type: string}
+  ms_power_automate_summary_text_size: {type: string, enum: ['default', 'small', 'medium', 'large', 'extraLarge']}
+  ms_power_automate_body_text_size: {type: string, enum: ['default', 'small', 'medium', 'large', 'extraLarge']}
   ms_power_automate_proxy: {type: string}
   ms_power_automate_alert_facts: *arrayOfMsPowerAutomateFacts
   ms_power_automate_kibana_discover_attach_url: {type: boolean}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -694,7 +694,7 @@ properties:
   ms_power_automate_alert_facts: *arrayOfMsPowerAutomateFacts
   ms_power_automate_kibana_discover_attach_url: {type: boolean}
   ms_power_automate_kibana_discover_title: {type: string}
-  ms_power_automate_kibana_discover_color: {type: string}
+  ms_power_automate_kibana_discover_color: {type: string, enum: ['default', 'positive', 'destructive']}
   ms_power_automate_ca_certs: {type: [boolean, string]}
   ms_power_automate_ignore_ssl_errors: {type: boolean}
   ms_power_automate_opensearch_discover_attach_url: {type: boolean}

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -688,6 +688,8 @@ properties:
   ### Microsoft Power Automate
   ms_power_automate_webhook_url: *arrayOfString
   ms_power_automate_alert_summary: {type: string}
+  ms_power_automate_summary_text_size: {type: string}
+  ms_power_automate_body_text_size: {type: string}
   ms_power_automate_proxy: {type: string}
   ms_power_automate_alert_facts: *arrayOfMsPowerAutomateFacts
   ms_power_automate_kibana_discover_attach_url: {type: boolean}

--- a/tests/alerters/powerautomate_test.py
+++ b/tests/alerters/powerautomate_test.py
@@ -41,7 +41,8 @@ def test_ms_power_automate(caplog):
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -130,7 +131,8 @@ def test_ms_power_automate_alert_facts():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -200,7 +202,8 @@ def test_ms_power_automate_proxy():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -259,7 +262,8 @@ def test_ms_power_automate_kibana_discover_attach_url_when_generated():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -327,7 +331,8 @@ def test_ms_power_automate_kibana_discover_color_when_positive():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -395,7 +400,8 @@ def test_ms_power_automate_kibana_discover_color_when_destructive():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -464,7 +470,8 @@ def test_ms_power_automate_teams_card_width_full():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
@@ -536,13 +543,158 @@ def test_ms_power_automate_kibana_discover_title():
                             "type": "TextBlock",
                             "text": rule['ms_power_automate_alert_summary'],
                             "weight": "Bolder",
-                            "size": "ExtraLarge",
+                            "wrap": True,
+                            "size": "large"
                         },
                         {
                             "type": "TextBlock",
                             "text": BasicMatchString(rule, match).__str__(),
                             "spacing": "Large",
                             "wrap": True
+                        }
+                    ],
+                    "actions": [
+                        {
+                            "type": "Action.OpenUrl",
+                            "title": rule['ms_power_automate_kibana_discover_title'],
+                            "url": match['kibana_discover_url'],
+                            "style": rule['ms_power_automate_kibana_discover_color']
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    mock_post_request.assert_called_once_with(
+        rule['ms_power_automate_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_ms_power_automate_summary_text_size_small():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_power_automate_kibana_discover_attach_url': True,
+        'ms_power_automate_kibana_discover_color': 'destructive',
+        'ms_power_automate_kibana_discover_title': 'See more',
+        'ms_power_automate_webhook_url': 'http://test.webhook.url',
+        'ms_power_automate_alert_summary': 'Alert from ElastAlert',
+        'ms_power_automate_summary_text_size': 'small',
+        'alert': [],
+        'alert_subject': 'Cool subject',
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsPowerAutomateAlerter(rule)
+    match = {
+        '@timestamp': '2024-07-19T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "type": "AdaptiveCard",
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "text": rule['ms_power_automate_alert_summary'],
+                            "weight": "Bolder",
+                            "wrap": True,
+                            "size": rule['ms_power_automate_summary_text_size']
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": BasicMatchString(rule, match).__str__(),
+                            "spacing": "Large",
+                            "wrap": True
+                        }
+                    ],
+                    "actions": [
+                        {
+                            "type": "Action.OpenUrl",
+                            "title": rule['ms_power_automate_kibana_discover_title'],
+                            "url": match['kibana_discover_url'],
+                            "style": rule['ms_power_automate_kibana_discover_color']
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    mock_post_request.assert_called_once_with(
+        rule['ms_power_automate_webhook_url'],
+        data=mock.ANY,
+        headers={'content-type': 'application/json'},
+        proxies=None,
+        verify=True
+    )
+    actual_data = json.loads(mock_post_request.call_args_list[0][1]['data'])
+    assert expected_data == actual_data
+
+
+def test_ms_power_automate_body_text_size_medium():
+    rule = {
+        'name': 'Test Rule',
+        'type': 'any',
+        'ms_power_automate_kibana_discover_attach_url': True,
+        'ms_power_automate_kibana_discover_color': 'destructive',
+        'ms_power_automate_kibana_discover_title': 'See more',
+        'ms_power_automate_webhook_url': 'http://test.webhook.url',
+        'ms_power_automate_alert_summary': 'Alert from ElastAlert',
+        'ms_power_automate_summary_text_size': 'small',
+        'ms_power_automate_body_text_size': 'medium',
+        'alert': [],
+        'alert_subject': 'Cool subject',
+    }
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = MsPowerAutomateAlerter(rule)
+    match = {
+        '@timestamp': '2024-07-19T00:00:00',
+        'kibana_discover_url': 'http://kibana#discover'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+
+    expected_data = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "type": "AdaptiveCard",
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "text": rule['ms_power_automate_alert_summary'],
+                            "weight": "Bolder",
+                            "wrap": True,
+                            "size": rule['ms_power_automate_summary_text_size'],
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": BasicMatchString(rule, match).__str__(),
+                            "spacing": "Large",
+                            "wrap": True,
+                            "size": rule['ms_power_automate_body_text_size']
                         }
                     ],
                     "actions": [


### PR DESCRIPTION
## Description

Adding the feature that adjusts the size of the summary and body in the ms_power_automate alert.

## Checklist

Created two tests for new feature and adjusted documentation.

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).
