### PR TITLE
Bump `python_requires`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.TBD.TBD
 
 ## Breaking changes
-- TBD
+- Drop python3.9, python3.10, python3.11 from `python_requires` - [#1528](https://github.com/jertel/elastalert2/pull/1528) - @kmurphy4
 
 ## New features
 - [MS Power Automate] New Alert Channel with Microsoft Power Automate - [#1505](https://github.com/jertel/elastalert2/pull/1505)  [#1513](https://github.com/jertel/elastalert2/pull/1513) [#1519](https://github.com/jertel/elastalert2/pull/1519) - @marssilva, @jertel

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                             'elastalert=elastalert.elastalert:main']},
     packages=find_packages(exclude=["tests"]),
     package_data={'elastalert': ['schema.yaml', 'es_mappings/**/*.json']},
-    python_requires='>=3.9',
+    python_requires='>=3.12',
     install_requires=[
         'apscheduler>=3.10.4,<4.0',
         'aws-requests-auth>=0.4.3',


### PR DESCRIPTION
## Description

According to https://elastalert2.readthedocs.io/en/latest/running_elastalert.html#as-a-python-package this package currently only supports Python 3.12, but that's not actually encoded in the project metadata.

As a result, people with older versions of Python can run

    $ pip install --upgrade elastalert2

and then hit runtime errors like https://github.com/jertel/elastalert2/issues/1400.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions. (n/a)
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Questions or Comments

Since older versions have already been published to PyPI with incorrect `python_requires`, this won't actually fix the bug (e.g., `python3.9 -m pip install --upgrade elastalert2` will select the incompatible 2.19.0 release).  I think if we wanted to fix that, we'd need to yank all the old releases, but that's probably not worthwhile..