### PR TITLE
Converting IRIS Alert Source from Hardcoded to Dynamic Alert Field Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Other changes
 - [Indexer] Fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
+- [IRIS] Changed alert_source field from static 'ElastAlert2' value to field iris_alert_source value with default of 'ElastAlert2' - @bvirgilioamnh
 
 # 2.19.0
 

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1201,6 +1201,8 @@ Optional:
 
 ``iris_alert_note``: Note for the alert.
 
+``iris-alert-source``: Source of the alert. Default value is ``ElastAlert2``.
+
 ``iris_alert_tags``: List of tags.
 
 ``iris_alert_status_id``: The alert status of the alert, default value is ``2``. This parameter requires an integer input.

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1201,7 +1201,7 @@ Optional:
 
 ``iris_alert_note``: Note for the alert.
 
-``iris-alert-source``: Source of the alert. Default value is ``ElastAlert2``.
+``iris_alert_source``: Source of the alert. Default value is ``ElastAlert2``.
 
 ``iris_alert_tags``: List of tags.
 

--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -27,6 +27,7 @@ class IrisAlerter(Alerter):
             'Authorization': f'Bearer {self.rule.get("iris_api_token")}'
         }
         self.alert_note = self.rule.get('iris_alert_note', None)
+        self.alert_source = self.rule.get('iris_alert_source', 'ElastAlert2')
         self.alert_tags = self.rule.get('iris_alert_tags', None)
         self.alert_status_id = self.rule.get('iris_alert_status_id', 2)
         self.alert_source_link = self.rule.get('iris_alert_source_link', None)
@@ -78,7 +79,7 @@ class IrisAlerter(Alerter):
         alert_data = {
             "alert_title": self.rule.get('name'),
             "alert_description": self.description,
-            "alert_source": "ElastAlert2",
+            "alert_source": self.alert_source,
             "alert_severity_id": self.alert_severity_id,
             "alert_status_id": self.alert_status_id,
             "alert_source_event_time": event_timestamp,

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -597,6 +597,7 @@ properties:
   iris_alert_note: {type: string}
   iris_alert_tags: {type: string}
   iris_alert_status_id: {type: integer, enum: [1, 2, 3, 4, 5, 6, 7]}
+  iris_alert_source: {type: string}
   iris_alert_source_link: {type: string}
   iris_alert_severity_id: {type: integer, enum: [1, 2, 3, 4, 5, 6]}
   iris_iocs: *arrayOfIrisIocFields

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -188,7 +188,7 @@ def test_iris_make_alert_maximal(caplog):
     expected_data = {
         "alert_title": 'Test Maximal Alert Body',
         "alert_description": 'test description in alert',
-        "alert_source": "ElastAlert2",
+        "alert_source": "TestSource",
         "alert_severity_id": 1,
         "alert_status_id": 2,
         "alert_source_event_time": '2023-10-21 20:00:00.000',
@@ -196,7 +196,6 @@ def test_iris_make_alert_maximal(caplog):
         "alert_tags": 'test, alert',
         "alert_customer_id": 1,
         "alert_source_link": 'https://example.com',
-        "alert_source": "TestSource",
         "alert_iocs": [
             {
                 'ioc_description': 'source address',
@@ -270,7 +269,7 @@ def test_iris_make_alert_maximal_with_nested_json(caplog):
     expected_data = {
         "alert_title": 'Test Maximal Alert Body',
         "alert_description": 'test description in alert',
-        "alert_source": "ElastAlert2",
+        "alert_source": "TestSource",
         "alert_severity_id": 1,
         "alert_status_id": 2,
         "alert_source_event_time": '2023-10-21 20:00:00.000',
@@ -278,7 +277,6 @@ def test_iris_make_alert_maximal_with_nested_json(caplog):
         "alert_tags": 'test, alert',
         "alert_customer_id": 1,
         "alert_source_link": 'https://example.com',
-        "alert_source": "TestSource",
         "alert_iocs": [
             {
                 'ioc_description': 'source address',

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -155,6 +155,7 @@ def test_iris_make_alert_maximal(caplog):
         'iris_alert_tags': 'test, alert',
         'iris_overwrite_timestamp': True,
         'iris_alert_source_link': 'https://example.com',
+        'iris_alert_source': "TestSource",
         'iris_iocs': [
             {
                 'ioc_description': 'source address',
@@ -195,6 +196,7 @@ def test_iris_make_alert_maximal(caplog):
         "alert_tags": 'test, alert',
         "alert_customer_id": 1,
         "alert_source_link": 'https://example.com',
+        "alert_source": "TestSource",
         "alert_iocs": [
             {
                 'ioc_description': 'source address',
@@ -235,6 +237,7 @@ def test_iris_make_alert_maximal_with_nested_json(caplog):
         'iris_alert_tags': 'test, alert',
         'iris_overwrite_timestamp': True,
         'iris_alert_source_link': 'https://example.com',
+        'iris_alert_source': "TestSource",
         'iris_iocs': [
             {
                 'ioc_description': 'source address',
@@ -275,6 +278,7 @@ def test_iris_make_alert_maximal_with_nested_json(caplog):
         "alert_tags": 'test, alert',
         "alert_customer_id": 1,
         "alert_source_link": 'https://example.com',
+        "alert_source": "TestSource",
         "alert_iocs": [
             {
                 'ioc_description': 'source address',


### PR DESCRIPTION
## Description

Updated the IRIS Alert Source field to read from the alert fields instead of being hardcoded. The alert source field has a default value of the original hardcoded value 'ElastAlert2'. This is to provided additional flexibility when using ElastAlert across multiple solutions.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
