### PR TITLE
Bugfix/1457 fixing iris ioc NoneType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Docs] Fixed typo in Alerta docs with incorrect number of seconds in a day. - @jertel
 - Update GitHub actions to avoid running publish workflows on forked branches. - @jertel
 - Rewrite `_find_es_dict_by_key` per [discussion #1450](https://github.com/jertel/elastalert2/discussions/1450) for fieldnames literally ending in `.keyword` [#1459](https://github.com/jertel/elastalert2/pull/1459) - @jmacdone @jertel
+- [IRIS] Fixed NoneType error raised in issue [#1457](https://github.com/jertel/elastalert2/issues/1457) - [#1533](https://github.com/jertel/elastalert2/pull/1533)
 
 # 2.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Other changes
 - [Indexer] Fixed fields types error on instance indexer_alert_config in schema.yml - [#1499](https://github.com/jertel/elastalert2/pull/1499) - @olehpalanskyi
+- [IRIS] Fixed NoneType error raised in issue [#1457](https://github.com/jertel/elastalert2/issues/1457) - [#1533](https://github.com/jertel/elastalert2/pull/1533)
 
 # 2.19.0
 
@@ -22,7 +23,6 @@
 - [Docs] Fixed typo in Alerta docs with incorrect number of seconds in a day. - @jertel
 - Update GitHub actions to avoid running publish workflows on forked branches. - @jertel
 - Rewrite `_find_es_dict_by_key` per [discussion #1450](https://github.com/jertel/elastalert2/discussions/1450) for fieldnames literally ending in `.keyword` [#1459](https://github.com/jertel/elastalert2/pull/1459) - @jmacdone @jertel
-- [IRIS] Fixed NoneType error raised in issue [#1457](https://github.com/jertel/elastalert2/issues/1457) - [#1533](https://github.com/jertel/elastalert2/pull/1533)
 
 # 2.18.0
 

--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -64,9 +64,11 @@ class IrisAlerter(Alerter):
     def make_iocs_records(self, matches):
         iocs = []
         for record in self.iocs:
-            record['ioc_value'] = lookup_es_key(matches[0], record['ioc_value'])
-            if record['ioc_value'] is not None:
-                iocs.append(record)
+            # Duplicating match record data so we can update the ioc_value without overwriting record
+            record_data = record.copy()
+            record_data['ioc_value'] = lookup_es_key(matches[0], record['ioc_value'])
+            if record_data['ioc_value'] is not None:
+                iocs.append(record_data)
         return iocs
 
     def make_alert(self, matches):

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -105,6 +105,72 @@ def test_iris_make_iocs_records(caplog):
     actual_data = alert.make_iocs_records([match])
     assert expected_data == actual_data
 
+def test_iris_handle_multiple_alerts_with_iocs(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'Test Context',
+        'type': 'any',
+        'iris_type': 'alert',
+        'iris_host': '127.0.0.1',
+        'iris_api_token': 'token 12345',
+        'iris_customer_id': 1,
+        'iris_iocs': [
+            {
+                'ioc_description': 'source address',
+                'ioc_tags': 'ip, ipv4',
+                'ioc_tlp_id': 1,
+                'ioc_type_id': 76,
+                'ioc_value': 'src_ip'
+            },
+            {
+                'ioc_description': 'target username',
+                'ioc_tags': 'login, username',
+                'ioc_tlp_id': 3,
+                'ioc_type_id': 3,
+                'ioc_value': 'username'
+            },
+            {
+                'ioc_description': 'empty ioc',
+                'ioc_tags': 'ioc',
+                'ioc_tlp_id': 3,
+                'ioc_type_id': 3,
+                'ioc_value': 'non_existent_data'
+            }
+        ],
+        'alert': []
+    }
+
+    rules_loader = FileRulesLoader({})
+    rules_loader.load_modules(rule)
+    alert = IrisAlerter(rule)
+
+    match = {
+        '@timestamp': '2023-10-21 20:00:00.000', 'username': 'evil_user', 'src_ip': '172.20.1.1', 'dst_ip': '10.0.0.1',
+        'event_type': 'login', 'event_status': 'success'
+    }
+
+    expected_data = [
+        {
+            'ioc_description': 'source address',
+            'ioc_tags': 'ip, ipv4',
+            'ioc_tlp_id': 1,
+            'ioc_type_id': 76,
+            'ioc_value': '172.20.1.1'
+        },
+        {
+            'ioc_description': 'target username',
+            'ioc_tags': 'login, username',
+            'ioc_tlp_id': 3,
+            'ioc_type_id': 3,
+            'ioc_value': 'evil_user'
+        }
+    ]
+
+    first_alert_data = alert.make_iocs_records([match])
+    actual_data = alert.make_iocs_records([match])
+    assert expected_data == actual_data
+
+
 
 def test_iris_make_alert_minimal(caplog):
     caplog.set_level(logging.INFO)

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -105,6 +105,7 @@ def test_iris_make_iocs_records(caplog):
     actual_data = alert.make_iocs_records([match])
     assert expected_data == actual_data
 
+
 def test_iris_handle_multiple_alerts_with_iocs(caplog):
     caplog.set_level(logging.INFO)
     rule = {
@@ -166,10 +167,10 @@ def test_iris_handle_multiple_alerts_with_iocs(caplog):
         }
     ]
 
-    first_alert_data = alert.make_iocs_records([match])
+    # Submitting a bogus alert to test follow up alerts
+    alert.make_iocs_records([match])
     actual_data = alert.make_iocs_records([match])
     assert expected_data == actual_data
-
 
 
 def test_iris_make_alert_minimal(caplog):


### PR DESCRIPTION
## Description

Simple PR to fix an issue with how the IRIS alerter handles IOCs in subsequent alerts. The error when the alerter inadvertently overwrites the IOCs dictionary when fetching key/value matches from Elastic. The solution is to simply copy the record data before updating it to ensure it is not overwritten.

I have also added a new test to explicitly test for this error in the future by calling make_alert() twice and validating the output of the second call.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

