### PR TITLE
Add timestamp_field to the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - [Docs] Mention the two available Spike-rule metrics that are add into the match record - [#1542](https://github.com/jertel/elastalert2/pull/1542) - @ulmako
+- [Docs] Add missing documentation of the timestamp_field option - [#1544](https://github.com/jertel/elastalert2/pull/1544) - @apollolv
 
 # 2.20.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -974,7 +974,7 @@ summary_suffix
 ``summary_suffix``: Specify a suffix string, which will be added after the aggregation summary table. This string is currently not subject to any formatting.
 
 timestamp_field
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 ``timestamp_field``: Specify the name of the document field containing the timestamp. 
 By default, the field ``@timestamp`` is used to query Elasticsearch. 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -142,6 +142,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           +
 | ``buffer_time`` (time, default from config.yaml)             |           |
 +--------------------------------------------------------------+           |
+| ``timestamp_field`` (string, default "@timestamp")           |           |
++--------------------------------------------------------------+           |
 | ``timestamp_type`` (string, default iso)                     |           |
 +--------------------------------------------------------------+           |
 | ``timestamp_format`` (string, default "%Y-%m-%dT%H:%M:%SZ")  |           |
@@ -970,6 +972,14 @@ summary_suffix
 ^^^^^^^^^^^^^^^^^^^^
 
 ``summary_suffix``: Specify a suffix string, which will be added after the aggregation summary table. This string is currently not subject to any formatting.
+
+timestamp_field
+^^^^^^^^^^^^^^
+
+``timestamp_field``: Specify the name of the document field containing the timestamp. 
+By default, the field ``@timestamp`` is used to query Elasticsearch. 
+If ``timestamp_field`` is set, this date field will be considered whenever querying, filtering and aggregating based on timestamps.
+(Optional, string, default @timestamp).
 
 timestamp_type
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

I noticed the documentation references `timestamp_field` in several places, but never actually documents the field itself.
I added a short description of what it does to the documentation.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments
As this changes no actual source code, I have skipped the tests.
I'm not sure if we need to mention this pure documentation change in the changelog?
