### PR TITLE
Support dynamic values via field substitution for the opsgenie_addr field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add support for Kibana 8.14/8.15 for Kibana Discover - [#1547](https://github.com/jertel/elastalert2/pull/1547) - @nsano-rururu
 - Upgrade pylint 3.1.0 to 3.3.1, pytest 8.0.2 to 8.3.3, pytest-cov 4.1.0 to 5.0.0, pytest-xdist 3.5.0 to 3.6.1, sphinx 7.2.6 to 8.0.2, sphinx_rtd_theme 2.0.0 to 3.0.1, tox 4.13.0 to 4.21.2  - [#1550](https://github.com/jertel/elastalert2/pull/1550) - @nsano-rururu
 - Upgrade to Python 3.13 - [#1551](https://github.com/jertel/elastalert2/pull/1551) - @nsano-rururu
+- [OpsGenie] Support dynamic `opsgenie_addr` values - [#1563](https://github.com/jertel/elastalert2/pull/1563) - @mohamedelema17
 
 # 2.20.0
 

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1786,7 +1786,7 @@ Optional:
 
 ``opsgenie_account``: The OpsGenie account to integrate with.
 
-``opsgenie_addr``: The OpsGenie URL to to connect against, default is ``https://api.opsgenie.com/v2/alerts``. If using the EU instance of Opsgenie, the URL needs to be ``https://api.eu.opsgenie.com/v2/alerts`` for requests to be successful.
+``opsgenie_addr``: The OpsGenie URL to to connect against, default is ``https://api.opsgenie.com/v2/alerts``. If using the EU instance of Opsgenie, the URL needs to be ``https://api.eu.opsgenie.com/v2/alerts`` for requests to be successful. The address can be formatted with fields from the first match e.g "https://api.opsgenie.com/v2/alerts/{my_alias}/close?identifierType=alias"
 
 ``opsgenie_recipients``: A list OpsGenie recipients who will be notified by the alert.
 

--- a/elastalert/alerters/opsgenie.py
+++ b/elastalert/alerters/opsgenie.py
@@ -126,7 +126,7 @@ class OpsGenieAlerter(Alerter):
         proxies = {'https': self.opsgenie_proxy} if self.opsgenie_proxy else None
 
         try:
-            r = requests.post(self.to_addr, json=post, headers=headers, proxies=proxies)
+            r = requests.post(self.to_addr.format(**matches[0]), json=post, headers=headers, proxies=proxies)
 
             elastalert_logger.debug('request response: {0}'.format(r))
             if r.status_code != 202:

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1258,3 +1258,33 @@ def test_opsgenie_get_details2():
     actual = alert.get_details(match)
     expected = {}
     assert expected == actual
+
+
+def test_formatted_opsgenie_addr(caplog):
+    caplog.set_level(logging.INFO)
+    rule = {
+        'name': 'testOGalert',
+        'opsgenie_key': 'ogkey',
+        'opsgenie_addr': 'https://api.opsgenie.com/v2/alerts/{alert_id}',
+        'type': mock_rule()
+    }
+    with mock.patch('requests.post') as mock_post:
+        rep = requests
+        rep.status_code = 202
+        url = rule.get('opsgenie_addr')
+        matches = [{'alert_id': '1234','@timestamp': '2014-10-31T00:00:00'}]
+        mock_post.return_value = rep
+        url.format(**matches[0])
+
+        alert = OpsGenieAlerter(rule)
+        alert.alert(matches)
+        mcal = mock_post._mock_call_args_list
+        assert mcal[0][0][0] == (f'https://api.opsgenie.com/v2/alerts/{matches[0].get("alert_id")}')
+        assert mock_post.called
+
+        assert mcal[0][1]['headers']['Authorization'] == 'GenieKey ogkey'
+        assert mcal[0][1]['json']['source'] == 'ElastAlert'
+        user, level, message = caplog.record_tuples[0]
+        assert "Error response from https://api.opsgenie.com/v2/alerts \n API Response: <MagicMock name='post()' id=" not in message
+        assert ('elastalert', logging.INFO, 'Alert sent to OpsGenie') == caplog.record_tuples[0]
+

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1268,18 +1268,23 @@ def test_formatted_opsgenie_addr(caplog):
         'opsgenie_addr': 'https://api.opsgenie.com/v2/alerts/{alert_id}',
         'type': mock_rule()
     }
-    with mock.patch('requests.post') as mock_post:
+    with (mock.patch('requests.post') as mock_post):
         rep = requests
         rep.status_code = 202
         url = rule.get('opsgenie_addr')
-        matches = [{'alert_id': '1234','@timestamp': '2014-10-31T00:00:00'}]
+        matches = [
+            {
+                'alert_id': '1234',
+                '@timestamp': '2014-10-31T00:00:00'
+            }
+        ]
         mock_post.return_value = rep
         url.format(**matches[0])
 
         alert = OpsGenieAlerter(rule)
         alert.alert(matches)
         mcal = mock_post._mock_call_args_list
-        assert mcal[0][0][0] == (f'https://api.opsgenie.com/v2/alerts/{matches[0].get("alert_id")}')
+        assert mcal[0][0][0] == f'https://api.opsgenie.com/v2/alerts/{matches[0].get("alert_id")}'
         assert mock_post.called
 
         assert mcal[0][1]['headers']['Authorization'] == 'GenieKey ogkey'

--- a/tests/alerters/opsgenie_test.py
+++ b/tests/alerters/opsgenie_test.py
@@ -1287,4 +1287,3 @@ def test_formatted_opsgenie_addr(caplog):
         user, level, message = caplog.record_tuples[0]
         assert "Error response from https://api.opsgenie.com/v2/alerts \n API Response: <MagicMock name='post()' id=" not in message
         assert ('elastalert', logging.INFO, 'Alert sent to OpsGenie') == caplog.record_tuples[0]
-


### PR DESCRIPTION
## Description

<!--
This pull request adds new feature where one to dynamically inject values into opsgenie_addr field. 
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Unit test is not necessary as the current tests sufficiently cover this small change.
<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
