### PR TITLE
restore support for Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.TBD.TBD
 
 ## Breaking changes
-- None
+- Note that version 2.21 upgraded Python to 3.13 and unintentionally dropped support for Python 3.12. This release, restores support for Python 3.12, while continuing to use Python 3.13 in the official ElastAlert 2 Docker image. Python 3.12 support will be dropped in a future release. - [#1585](https://github.com/jertel/elastalert2/pull/1585) - @jertel
 
 ## New features
 - None
@@ -12,7 +12,7 @@
 # 2.21.0
 
 ## Breaking changes
-- None
+- Be aware that this version dropped support for Python 3.12. It was re-added in the following release due to some distributions not yet supporting Python 3.13.
 
 ## New features
 - [Notifications] System error notifications can now be delivered via the same set of alerters as rule alerts - [#1546](https://github.com/jertel/elastalert2/pull/1546) - @jertel

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -146,7 +146,7 @@ Requirements
 
 - Elasticsearch 7.x or 8.x, or OpenSearch 1.x or 2.x
 - ISO8601 or Unix timestamped data
-- Python 3.13. Require OpenSSL 3.0.8 or newer.
+- Python 3.13. Require OpenSSL 3.0.8 or newer. Note that Python 3.12 is still supported but will be removed in a future release.
 - pip
 - Packages on Ubuntu 24.04: build-essential python3-pip python3.13 python3.13-dev libffi-dev libssl-dev
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                             'elastalert=elastalert.elastalert:main']},
     packages=find_packages(exclude=["tests"]),
     package_data={'elastalert': ['schema.yaml', 'es_mappings/**/*.json']},
-    python_requires='>=3.13',
+    python_requires='>=3.12',
     install_requires=[
         'apscheduler>=3.10.4,<4.0',
         'aws-requests-auth>=0.4.3',


### PR DESCRIPTION
## Description

Restores support for Python 3.12 while continuing to use Python 3.13 with testing and the official ElastAlert 2 image.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [N/A] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [N/A] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
