### PR TITLE
Add `aggregation_alert_time_compared_with_timestamp_field` documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 ## Other changes
-- None
+- [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1555](https://github.com/jertel/elastalert2/discussions/1555) - @nicolasnovelli
 
 # 2.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 ## Other changes
-- [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1555](https://github.com/jertel/elastalert2/discussions/1555) - @nicolasnovelli
+- [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1588](https://github.com/jertel/elastalert2/pull/1588) - @nicolasnovelli
 
 # 2.22.0
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -526,6 +526,17 @@ aggregate_by_match_time
 Setting this to true will cause aggregations to be created relative to the timestamp of the first event, rather than the current time. This
 is useful for querying over historic data or if using a very large buffer_time and you want multiple aggregations to occur from a single query.
 
+aggregation_alert_time_compared_with_timestamp_field
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``aggregation_alert_time_compared_with_timestamp_field``: This option controls how aggregation works when a rule processes events
+older than ``current time - aggregation window`` and ``aggregate_by_match_time`` is set to true. Defaults to false.
+When false, the expected send timestamp of the pending alert (waiting for additional events to aggregate) is compared with the current time.
+As a result, following events will not be aggregated with the pending alert, because it is considered already notified,
+leading to past events being notified one by one instead of being grouped together.
+When true, it allows the aggregation of events with old timestamps, as long as they are within the aggregation window.
+(Optional, boolean, default false)
+
 realert
 ^^^^^^^
 


### PR DESCRIPTION
## Description

Adds documentation for option `aggregation_alert_time_compared_with_timestamp_field`, as discussed in [#1555](https://github.com/jertel/elastalert2/discussions/1555).

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
