### PR TITLE
Add `--prometheus_addr` command line parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## New features
 - [Helm] Add optional liveness and readiness probe - [#1604](https://github.com/jertel/elastalert2/pull/1604) - @aizerin
 - Add `include_rule_params_in_matches` rule parameter to enable copying of specific rule params into match data - [#1605](https://github.com/jertel/elastalert2/pull/1605) - @jertel
-- Add `--prometheus_addr` command line parameter to allow binding the Prometheus metrics server on a different host address - [#1608](https://github.com/jertel/elastalert2/pull/1608)
+- Add `--prometheus_addr` command line parameter to allow binding the Prometheus metrics server on a different host address - [#1608](https://github.com/jertel/elastalert2/pull/1608) - @tgxworld
 
 ## Other changes
 - [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1588](https://github.com/jertel/elastalert2/pull/1588) - @nicolasnovelli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## New features
 - [Helm] Add optional liveness and readiness probe - [#1604](https://github.com/jertel/elastalert2/pull/1604) - @aizerin
 - Add `include_rule_params_in_matches` rule parameter to enable copying of specific rule params into match data - [#1605](https://github.com/jertel/elastalert2/pull/1605) - @jertel
+- Add `--prometheus_addr` command line parameter to allow binding the Prometheus metrics server on a different host address - [#1608](https://github.com/jertel/elastalert2/pull/1608)
 
 ## Other changes
 - [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1588](https://github.com/jertel/elastalert2/pull/1588) - @nicolasnovelli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## New features
 - [Helm] Add optional liveness and readiness probe - [#1604](https://github.com/jertel/elastalert2/pull/1604) - @aizerin
 - Add `include_rule_params_in_matches` rule parameter to enable copying of specific rule params into match data - [#1605](https://github.com/jertel/elastalert2/pull/1605) - @jertel
-- Add `--prometheus_addr` command line parameter to allow binding the Prometheus metrics server on a different host address - [#1608](https://github.com/jertel/elastalert2/pull/1608) - @tgxworld
+- [Helm] Add `--prometheus_addr` command line parameter to allow binding the Prometheus metrics server on a different host address - [#1608](https://github.com/jertel/elastalert2/pull/1608) - @tgxworld
 
 ## Other changes
 - [Docs] Add missing documentation of the `aggregation_alert_time_compared_with_timestamp_field` option. - [#1588](https://github.com/jertel/elastalert2/pull/1588) - @nicolasnovelli

--- a/docs/source/flags.rst
+++ b/docs/source/flags.rst
@@ -31,6 +31,8 @@ based on changes to their config files.
 ``--prometheus_port`` exposes ElastAlert 2 `Prometheus metrics <https://elastalert2.readthedocs.io/en/latest/recipes/exposing_rule_metrics.html>`_ on the specified
 port. Prometheus metrics disabled by default.
 
+``--prometheus_addr`` allows you to specify the host address that the Prometheus metrics server will bind to.
+
 ``--rule <rule.yaml>`` will only run the given rule. The rule file may be a
 complete file path or a filename in ``rules_folder`` or its subdirectories.
 

--- a/docs/source/recipes/exposing_rule_metrics.rst
+++ b/docs/source/recipes/exposing_rule_metrics.rst
@@ -13,6 +13,12 @@ To expose ElastAlert rule metrics on port ``9979`` run the following command:
 
     $ elastalert --config config.yaml --prometheus_port 9979 
 
+The ``--prometheus_addr`` configuration flag can also be used to bind the Prometheus metrics server to a different host address.
+
+.. code-block:: console
+
+   $ elastalert --config config.yaml --prometheus_port 9979 --prometheus_addr "::"
+
 Rule Metrics
 ------------
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -94,6 +94,14 @@ class ElastAlerter(object):
             help='Enable logging from Elasticsearch queries as curl command. Queries will be logged to file. Note that '
                  'this will incorrectly display localhost:9200 as the host/port')
         parser.add_argument('--prometheus_port', type=int, dest='prometheus_port', help='Enables Prometheus metrics on specified port.')
+
+        parser.add_argument(
+            '--prometheus_addr',
+            type=str,
+            dest='prometheus_addr',
+            default=None,
+            help='Address to bind the Prometheus metrics server on.')
+
         self.args = parser.parse_args(args)
 
     def __init__(self, args):
@@ -175,6 +183,7 @@ class ElastAlerter(object):
             self.statsd = None
         self.add_metadata_alert = self.conf.get('add_metadata_alert', False)
         self.prometheus_port = self.args.prometheus_port
+        self.prometheus_addr = self.args.prometheus_addr
         self.show_disabled_rules = self.conf.get('show_disabled_rules', True)
         self.pretty_ts_format = self.conf.get('custom_pretty_ts_format')
 

--- a/elastalert/prometheus_wrapper.py
+++ b/elastalert/prometheus_wrapper.py
@@ -7,6 +7,7 @@ class PrometheusWrapper:
 
     def __init__(self, client):
         self.prometheus_port = client.prometheus_port
+        self.prometheus_addr = client.prometheus_addr
         self.run_rule = client.run_rule
         self.writeback = client.writeback
 
@@ -24,7 +25,7 @@ class PrometheusWrapper:
         self.prom_alerts_silenced = prometheus_client.Counter('elastalert_alerts_silenced', 'Number of silenced alerts', ['rule_name'])
 
     def start(self):
-        prometheus_client.start_http_server(self.prometheus_port)
+        prometheus_client.start_http_server(port=self.prometheus_port, addr=self.prometheus_addr)
 
     def metrics_run_rule(self, rule, endtime, starttime=None):
         """ Increment counter every time rule is run """


### PR DESCRIPTION
This commit adds support for the `--prometheus_addr` command line
parameter to allow binding the Prometheus metrics server on a different
host address.

### Reviewer notes

> Helm Chart: If your new feature introduces settings consider adding those to the Helm chart [README.md](https://github.com/jertel/elastalert2/blob/master/chart/elastalert2/README.md) and [values.yaml](https://github.com/jertel/elastalert2/blob/master/chart/elastalert2/values.yaml)

I'm not quite sure how to do this so would like to get some help here if possible.
