### PR TITLE
Validate if ref is not None

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -523,7 +523,7 @@ class SpikeRule(RuleType):
     def find_matches(self, ref, cur):
         """ Determines if an event spike or dip happening. """
         # Apply threshold limits
-        if self.field_value is None and cur is not None:
+        if self.field_value is None and cur is not None and ref is not None:
             if (cur < self.rules.get('threshold_cur', 0) or
                     ref < self.rules.get('threshold_ref', 0)):
                 return False


### PR DESCRIPTION
## Description

elastalert2-1 | File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 528, in find_matches elastalert2-1 | ref < self.rules.get('threshold_ref', 0)): elastalert2-1 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ elastalert2-1 | TypeError: '<' not supported between instances of 'NoneType' and 'int'

ref is now checked before comparison.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

Simple change validated with @jertel
