### PR TITLE
IRIS Alerter Description Overwrite Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Other changes
 - Fix `schema.yaml` to support Kibana 8.17 - [#1631](https://github.com/jertel/elastalert2/pull/1631) - @vpiserchia
 - [Helm] Clarified documentation around rootRulesFolder - @jertel
-- [IRIS] Fix `iris.py` to overcome a description overwriting bug - @jmolletAMNH
+- [IRIS] Fix `iris.py` to overcome a description overwriting bug - [#1643](https://github.com/jertel/elastalert2/pull/1643) - @jmolletAMNH
 
 # 2.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Other changes
 - Fix `schema.yaml` to support Kibana 8.17 - [#1631](https://github.com/jertel/elastalert2/pull/1631) - @vpiserchia
 - [Helm] Clarified documentation around rootRulesFolder - @jertel
+- [IRIS] Fix `iris.py` to overcome a description overwriting bug - @jmolletAMNH
 
 # 2.23.0
 

--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -77,10 +77,6 @@ class IrisAlerter(Alerter):
             event_timestamp = matches[0].get('@timestamp')
         else:
             event_timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-
-        # If no description is supplied use the built-in alert body generator which accounts for alert_text and alert_text_args
-        if not self.description:
-            self.description = self.create_alert_body(matches)
         
         alert_data = {
             "alert_title": self.create_title(matches),
@@ -93,6 +89,12 @@ class IrisAlerter(Alerter):
             "alert_tags": self.alert_tags,
             "alert_customer_id": self.customer_id,
         }
+
+        # If there is an exisiting description, it will populate in alert_data otherwise update the alert_data with the create_alert_body data.
+        if not self.description:
+            alert_data.update(
+                {"alert_description": self.create_alert_body(matches)}
+            ) 
 
         if self.alert_source_link:
             alert_data.update(

--- a/tests/alerters/iris_test.py
+++ b/tests/alerters/iris_test.py
@@ -378,6 +378,7 @@ event_status: success\nevent_type: login\nsrc_ip: 172.20.1.1\nusername: evil_use
     actual_data = alert.make_alert([match])
     assert expected_data == actual_data
 
+
 def test_iris_make_alert_auto_description_realert(caplog):
     """Test for the built-in elastalert2 create_title and create_body functions
 
@@ -510,6 +511,7 @@ event_status: failure\nevent_type: login\nsrc_ip: 192.168.125.33\nusername: good
     assert first_expected_data == first_data
     assert second_expected_data == second_data
 
+
 def test_iris_make_alert_auto_blank_description_realert(caplog):
     """Test for the built-in elastalert2 create_title and create_body functions
 
@@ -641,6 +643,7 @@ event_status: failure\nevent_type: login\nsrc_ip: 192.168.125.33\nusername: good
 
     assert first_expected_data == first_data
     assert second_expected_data == second_data
+
 
 def test_iris_make_alert_auto_description_args(caplog):
     """Test for the built-in elastalert2 create_title and create_body functions


### PR DESCRIPTION
## Description

<!--
The IRIS Alerter has a bug that causes the description of alerts to be overwritten if the alerter is called more than once a session. The committed changes fix this and implement corresponding tests.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

The documentation was not updated because this is a bug fix and does not change any functionality.