### PR TITLE
add _formatted to metric agg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fix `schema.yaml` to support Kibana 8.17 - [#1631](https://github.com/jertel/elastalert2/pull/1631) - @vpiserchia
 - [Helm] Clarified documentation around rootRulesFolder - @jertel
 - [IRIS] Fix `iris.py` to overcome a description overwriting bug - [#1643](https://github.com/jertel/elastalert2/pull/1643) - @jmolletAMNH
-- Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation - [#1647](https://github.com/jertel/elastalert2/pull/1647) - @dennis-trapp
+- Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation when using compound query keys - [#1647](https://github.com/jertel/elastalert2/pull/1647) - @dennis-trapp
 
 # 2.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fix `schema.yaml` to support Kibana 8.17 - [#1631](https://github.com/jertel/elastalert2/pull/1631) - @vpiserchia
 - [Helm] Clarified documentation around rootRulesFolder - @jertel
 - [IRIS] Fix `iris.py` to overcome a description overwriting bug - [#1643](https://github.com/jertel/elastalert2/pull/1643) - @jmolletAMNH
-- Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation - @dennis-trapp
+- Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation - [#1647](https://github.com/jertel/elastalert2/pull/1647) - @dennis-trapp
 
 # 2.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix `schema.yaml` to support Kibana 8.17 - [#1631](https://github.com/jertel/elastalert2/pull/1631) - @vpiserchia
 - [Helm] Clarified documentation around rootRulesFolder - @jertel
 - [IRIS] Fix `iris.py` to overcome a description overwriting bug - [#1643](https://github.com/jertel/elastalert2/pull/1643) - @jmolletAMNH
+- Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation - @dennis-trapp
 
 # 2.23.0
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1146,6 +1146,10 @@ class MetricAggregationRule(BaseAggregationRule):
                     # add compound key to payload to allow alerts to trigger for every unique occurence
                     compound_value = [match_data[key] for key in self.rules['compound_query_key']]
                     match_data[self.rules['query_key']] = ",".join([str(value) for value in compound_value])
+                    metric_format_string = self.rules.get('metric_format_string', None)
+                    if metric_format_string:
+                        match_data[self.metric_key +'_formatted'] = format_string(metric_format_string, metric_val)
+                        match_data['metric_agg_value_formatted'] = format_string(metric_format_string, metric_val)
                     self.add_match(match_data)
 
     def crossed_thresholds(self, metric_value):


### PR DESCRIPTION
## Description

Add `metric_<metric_key>_formatted` and `metric_agg_value_formatted` to metric aggregation

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I believe this resolves https://github.com/jertel/elastalert2/discussions/1634, however I would appreciate a second set of eyes on this.