### PR TITLE
Feature/pagerduty custom details update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - [Helm] Fix `--namespace` and `namespaceOverride` value in Helm charts - [#1662](https://github.com/jertel/elastalert2/pull/1662) - @lepouletsuisse
+- [Pager Duty] Expand `pagerduty_v2_payload_custom_details` to allow defaulting to value of provided key:value pair if the value is not found as a key in an elastalert match. - [#1674](https://github.com/jertel/elastalert2/pull/1674) - @mark-trellix
 
 # 2.24.0
 

--- a/docs/source/alerts.rst
+++ b/docs/source/alerts.rst
@@ -1895,7 +1895,7 @@ See https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Nw-send-an-event-t
 
 ``pagerduty_v2_payload_source_args``: If set, and ``pagerduty_v2_payload_source`` is a formattable string, ElastAlert 2 will format the source based on the provided array of fields from the rule or match.
 
-``pagerduty_v2_payload_custom_details``: List of keys:values to use as the content of the custom_details payload. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip.
+``pagerduty_v2_payload_custom_details``: List of keys:values to use as the content of the custom_details payload. For each key:value, it first attempts to map the provided value by checking if it exists as a key in an elastalert match. If a match is found, it assigns the corresponding value from the elastalert match. If no match is found, it then defaults to using the original provided value directly.
 
 ``pagerduty_v2_payload_include_all_info``: If True, this will include the entire Elasticsearch document as a custom detail field called "information" in the PagerDuty alert.
 

--- a/elastalert/alerters/pagerduty.py
+++ b/elastalert/alerters/pagerduty.py
@@ -50,7 +50,7 @@ class PagerDutyAlerter(Alerter):
             if self.pagerduty_v2_payload_custom_details:
                 for match in matches:
                     for custom_details_key, es_key in list(self.pagerduty_v2_payload_custom_details.items()):
-                        custom_details_payload[custom_details_key] = lookup_es_key(match, es_key)
+                        custom_details_payload[custom_details_key] = lookup_es_key(match, es_key) or es_key
 
             payload = {
                 'routing_key': self.pagerduty_service_key,

--- a/tests/alerters/pagerduty_test.py
+++ b/tests/alerters/pagerduty_test.py
@@ -289,7 +289,7 @@ def test_pagerduty_alerter_v2_payload_custom_details():
         'pagerduty_v2_payload_group': 'app-stack',
         'pagerduty_v2_payload_severity': 'error',
         'pagerduty_v2_payload_source': 'mysql.host.name',
-        'pagerduty_v2_payload_custom_details': {'a': 'somefield', 'c': 'f'},
+        'pagerduty_v2_payload_custom_details': {'timestamp': '@timestamp', 'key-match': 'somefield', 'static': 'generic-string'},
         'alert': []
     }
     rules_loader = FileRulesLoader({})
@@ -311,8 +311,9 @@ def test_pagerduty_alerter_v2_payload_custom_details():
             'source': 'mysql.host.name',
             'summary': 'Test PD Rule',
             'custom_details': {
-                'a': 'foobarbaz',
-                'c': None,
+                'timestamp': '2017-01-01T00:00:00',
+                'key-match': 'foobarbaz',
+                'static': 'generic-string',
                 'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: foobarbaz\n'
             },
             'timestamp': '2017-01-01T00:00:00'


### PR DESCRIPTION
If the value of a key:value pair given is not found as a key in an elastalert match then default to using the original value of the key:value pair.

Updated alert document reflecting change and describe logic better.

## Description

Expand custom details to allow defaulting to value of provided key:value pair if the value is not found as a key in an elastalert match.

<!--
Provide a description for your pull request. Note any breaking changes.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I noticed when looking at this functionality that this and the logic before these changes assumes that all elastalert matches will each have the value as a key from the provided key:value pair.

See here where it loops over all matches. Following the logic it will only end up assigning/overwriting to the last looped match in matches.
https://github.com/jertel/elastalert2/blob/55e26593679ca9e7468fd9925dfdd091ab27dcdd/elastalert/alerters/pagerduty.py#L50-L53

If it's assumed all matches are the same, I don't see the need for looping over the matches. Please correct me if I am wrong.

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
