### PR TITLE
added support for ES 9 and OS 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 - None
 
 ## New features
-- None
+- Now supporting Elasticsearch 9 and OpenSearch 3 - [#1682](https://github.com/jertel/elastalert2/pull/1682) - @jertel
 
 ## Other changes
-- None
+- Removed specific version requirement for Elastic Kibana and OpenSearch Discover - [#1682](https://github.com/jertel/elastalert2/pull/1682) - @jertel
 
 # 2.25.0
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ A [Helm chart][7] is also included for easy configuration as a Kubernetes deploy
 
 Documentation, including an FAQ, for ElastAlert 2 can be found on [readthedocs.com][3]. This is the place to start if you're not familiar with ElastAlert 2 at all.
 
-Elasticsearch 8 support is documented in the [FAQ][12].
-
 The full list of platforms that ElastAlert 2 can fire alerts into can be found [in the documentation][4].
 
 ## Contributing

--- a/docs/source/recipes/faq.rst
+++ b/docs/source/recipes/faq.rst
@@ -444,10 +444,10 @@ Example 2 - Avoiding escaping altogether by enclosing double quotes within singl
         query_string:
           query: '"Rabbia Al"'
 
-Does ElastAlert 2 support Elasticsearch 8?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How do I migrate from Elastic 7 to Elastic 8?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ElastAlert 2 supports Elasticsearch 8.
+ElastAlert 2 supports Elasticsearch 8 but requires new indices to be created.
 
 To upgrade an existing ElastAlert 2 installation to Elasticsearch 8 the
 following manual steps are required (note the important WARNING below):
@@ -464,6 +464,11 @@ following manual steps are required (note the important WARNING below):
 * Restart ElastAlert 2.
 
 WARNING: Failure to remove the old ElastAlert indices can result in a non-working Elasticsearch cluster. This is because the ElastAlert indices contain deprecated features and the Elasticsearch 8 upgrade logic is currently flawed and does not correctly handle this situation. The Elasticsearch GitHub repository contains [more information](https://github.com/elastic/elasticsearch/issues/84199) on this problem.
+
+How do I migrate from Elastic 8 to Elastic 9?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ElastAlert 2 supports Elasticsearch 9. No manual ElastAlert 2 steps are required, however Elastic does require that the Elasticsearch cluster first be upgraded to 8.18 before proceeding to 9.x.
 
 Support multiple sns_topic_arn in Alert Amazon SNS(Simple Notification Service)?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/recipes/signing_requests.rst
+++ b/docs/source/recipes/signing_requests.rst
@@ -10,11 +10,11 @@ OpenSearch and Elasticsearch.
 Signing requests to Amazon OpenSearch Service
 ================================================
 
-When using Amazon OpenSearch Service, you need to secure your Elasticsearch
-from the outside. Currently, there is no way to secure your Elasticsearch using
-network firewall rules, so the only way is to signing the requests using the
+When using Amazon OpenSearch Service, you need to secure your service
+from unauthorized access. Currently, there is no way to secure this using
+network firewall rules, so the only way is via signing the requests using the
 access key and secret key for a role or user with permissions on the
-Elasticsearch service.
+OpenSearch service.
 
 You can sign requests to AWS using any of the standard AWS methods of providing
 credentials.
@@ -34,7 +34,7 @@ specify the ``aws_region`` in the configuration file or set the
 Using AWS profiles
 ------------------
 
-You can also create a user with permissions on the Elasticsearch service and
+You can also create a user with permissions on the OpenSearch service and
 tell ElastAlert 2 to authenticate itself using that user. First, create an AWS
 profile in the machine where you'd like to run ElastAlert 2 for the user with
 permissions.

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -776,22 +776,21 @@ kibana_discover_security_tenant
 kibana_discover_version
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-``kibana_discover_version``: Specifies the version of the Kibana Discover application.
+``kibana_discover_version``: Older version of Kibana use an obsolete URL shortener API. If using a version between 7.0 and 7.15 you must specify that major and minor version here.
 
-The currently supported versions of Kibana Discover are:
+Note that ElastAlert 2 only supports Kibana version 7.0 or newer.
 
-- `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `7.5`, `7.6`, `7.7`, `7.8`, `7.9`, `7.10`, `7.11`, `7.12`, `7.13`, `7.14`, `7.15`, `7.16`, `7.17`
-- `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`, `8.6`, `8.7`, `8.8`, `8.9` , `8.10` , `8.11` , `8.12` , `8.13`, `8.14`, `8.15`, `8.16`, `8.17`
+Example:
 
 ``kibana_discover_version: '7.15'``
 
 kibana_discover_index_pattern_id
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``kibana_discover_index_pattern_id``: The id of the index pattern to link to in the Kibana Discover application.
-These ids are usually generated and can be found in url of the index pattern management page, or by exporting its saved object.
+``kibana_discover_index_pattern_id``: The id of the data view to link to in the Kibana Discover application.
+These ids are usually generated and can be found in url of the ``Data Views`` page, or by exporting its saved object.
 
-In this documentation all references of "index pattern" refer to the similarly named concept in Kibana 8 called "data view".
+In this documentation all references of "index pattern" refer to the similarly named concept in Kibana 8+ called "data view".
 
 Example export of an index pattern's saved object:
 
@@ -890,11 +889,11 @@ This value should be relative to the base opensearch url defined by ``opensearch
 opensearch_discover_version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``opensearch_discover_version``: Specifies the version of the opensearch Discover application.
+``opensearch_discover_version``: Specifies the version of the opensearch Discover application. Currently unused.
 
-The currently supported versions of opensearch Discover are:
+Note that ElastAlert 2 only supports Discover version 2.11 or newer.
 
-- `2.11`
+Example:
 
 ``opensearch_discover_version: '2.11'``
 

--- a/docs/source/running_elastalert.rst
+++ b/docs/source/running_elastalert.rst
@@ -144,7 +144,7 @@ challenging due to the numerous differences between everyone's environment.
 Requirements
 ------------
 
-- Elasticsearch 7.x or 8.x, or OpenSearch 1.x or 2.x
+- Elasticsearch 7, 8, or 9 or OpenSearch 1, 2, or 3
 - ISO8601 or Unix timestamped data
 - Python 3.13. Require OpenSSL 3.0.8 or newer. Note that Python 3.12 is still supported but will be removed in a future release.
 - pip

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -14,11 +14,6 @@ from .util import ts_add
 
 kibana_default_timedelta = datetime.timedelta(minutes=10)
 
-kibana_versions = frozenset([
-        '7.0', '7.1', '7.2', '7.3', '7.4', '7.5', '7.6', '7.7', '7.8', '7.9', '7.10', '7.11', '7.12', '7.13', '7.14', '7.15', '7.16', '7.17', 
-        '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6', '8.7', '8.8', '8.9', '8.10', '8.11', '8.12', '8.13', '8.14', '8.15', '8.16', '8.17'
-        ])
-
 def generate_kibana_discover_url(rule, match):
     ''' Creates a link for a kibana discover app. '''
 
@@ -26,15 +21,6 @@ def generate_kibana_discover_url(rule, match):
     if not discover_app_url:
         elastalert_logger.warning(
             'Missing kibana_discover_app_url for rule %s' % (
-                rule.get('name', '<MISSING NAME>')
-            )
-        )
-        return None
-
-    kibana_version = rule.get('kibana_discover_version')
-    if not kibana_version:
-        elastalert_logger.warning(
-            'Missing kibana_discover_version for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )
@@ -64,18 +50,8 @@ def generate_kibana_discover_url(rule, match):
     to_timedelta = rule.get('kibana_discover_to_timedelta', timeframe)
     to_time = ts_add(timestamp, to_timedelta)
 
-    if kibana_version in kibana_versions:
-        globalState = kibana7_disover_global_state(from_time, to_time)
-        appState = kibana_discover_app_state(index, columns, filters, query_keys, match)
-
-    else:
-        elastalert_logger.warning(
-            'Unknown kibana discover application version %s for rule %s' % (
-                kibana_version,
-                rule.get('name', '<MISSING NAME>')
-            )
-        )
-        return None
+    globalState = kibana7_disover_global_state(from_time, to_time)
+    appState = kibana_discover_app_state(index, columns, filters, query_keys, match)
 
     return "%s?_g=%s&_a=%s" % (
         os.path.expandvars(discover_app_url),

--- a/elastalert/kibana_external_url_formatter.py
+++ b/elastalert/kibana_external_url_formatter.py
@@ -136,8 +136,12 @@ def create_kibana_auth(kibana_url, rule) -> AuthBase:
 
 def is_kibana_atleastsevensixteen(version: str):
     """
-    Returns True when the Kibana server version >= 7.16
+    Returns True when the Kibana server version >= 7.16 or is unspecified
     """
+    version = version.strip() if version else '0.0'
+    if not version or version == '0.0':
+        return True
+
     major, minor = list(map(int, version.split(".")[:2]))
     return major > 7 or (major == 7 and minor >= 16)
 

--- a/elastalert/opensearch_discover.py
+++ b/elastalert/opensearch_discover.py
@@ -14,10 +14,6 @@ from .util import ts_add
 
 opensearch_default_timedelta = datetime.timedelta(minutes=10)
 
-opensearch_versions = frozenset([
-        '2.11'
-        ])
-
 def generate_opensearch_discover_url(rule, match):
     ''' Creates a link for a opensearch discover app. '''
 
@@ -25,15 +21,6 @@ def generate_opensearch_discover_url(rule, match):
     if not discover_app_url:
         elastalert_logger.warning(
             'Missing opensearch_discover_app_url for rule %s' % (
-                rule.get('name', '<MISSING NAME>')
-            )
-        )
-        return None
-
-    opensearch_version = rule.get('opensearch_discover_version')
-    if not opensearch_version:
-        elastalert_logger.warning(
-            'Missing opensearch_discover_version for rule %s' % (
                 rule.get('name', '<MISSING NAME>')
             )
         )
@@ -63,19 +50,9 @@ def generate_opensearch_discover_url(rule, match):
     to_timedelta = rule.get('opensearch_discover_to_timedelta', timeframe)
     to_time = ts_add(timestamp, to_timedelta)
 
-    if opensearch_version in opensearch_versions:
-        globalState = opensearch_disover_global_state(from_time, to_time)
-        appState = opensearch_discover_app_state(index, columns, filters, query_keys, match)
-        appFilter = opensearch_discover_app_filter(index, columns, filters, query_keys, match)
-
-    else:
-        elastalert_logger.warning(
-            'Unknown opensearch discover application version %s for rule %s' % (
-                opensearch_version,
-                rule.get('name', '<MISSING NAME>')
-            )
-        )
-        return None
+    globalState = opensearch_disover_global_state(from_time, to_time)
+    appState = opensearch_discover_app_state(index, columns, filters, query_keys, match)
+    appFilter = opensearch_discover_app_filter(index, columns, filters, query_keys, match)
 
     urlqueryOriginal = "%s?_g=%s&_a=%s&_q=%s" % (
         os.path.expandvars(discover_app_url),

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -326,7 +326,7 @@ properties:
   generate_kibana_discover_url: {type: boolean}
   shorten_kibana_discover_url: {type: boolean}
   kibana_discover_app_url: {type: string}
-  kibana_discover_version: {type: string, enum: ['8.17','8.16','8.15','8.14','8.13','8.12','8.11', '8.10', '8.9', '8.8', '8.7', '8.6', '8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.17', '7.16', '7.15', '7.14', '7.13', '7.12', '7.11', '7.10', '7.9', '7.8', '7.7', '7.6', '7.5', '7.4', '7.3', '7.2', '7.1', '7.0']}
+  kibana_discover_version: {type: string}
   kibana_discover_index_pattern_id: {type: string, minLength: 1}
   kibana_discover_columns: {type: array, items: {type: string, minLength: 1}, minItems: 1}
   kibana_discover_from_timedelta: *timedelta
@@ -337,7 +337,7 @@ properties:
   generate_opensearch_discover_url: {type: boolean}
   opensearch_url: {type: string, format: uri}
   opensearch_discover_app_url: {type: string}
-  opensearch_discover_version: {type: string, enum: ['2.11']}
+  opensearch_discover_version: {type: string}
   opensearch_discover_index_pattern_id: {type: string, minLength: 1}
   opensearch_discover_columns: {type: array, items: {type: string, minLength: 1}, minItems: 1}
   opensearch_discover_from_timedelta: *timedelta

--- a/tests/kibana_discover_test.py
+++ b/tests/kibana_discover_test.py
@@ -24,23 +24,10 @@ from elastalert.kibana_discover import generate_kibana_discover_url
     '7.15',
     '7.16',
     '8.0',
-    '8.1',
-    '8.2',
-    '8.3',
-    '8.4',
-    '8.5',
-    '8.6',
-    '8.7',
-    '8.8',
-    '8.9',
-    '8.10',
-    '8.11',
-    '8.12',
-    '8.13',
-    '8.14',
-    '8.15',
-    '8.16',
-    '8.17'
+    '8.17',
+    ' ',
+    '0.0',
+    ''
 ])
 def test_generate_kibana_discover_url_with_kibana_7x(kibana_version):
     url = generate_kibana_discover_url(
@@ -110,15 +97,32 @@ def test_generate_kibana_discover_url_with_missing_kibana_discover_version():
     url = generate_kibana_discover_url(
         rule={
             'kibana_discover_app_url': 'http://kibana:5601/#/discover',
-            'kibana_discover_index_pattern_id': 'logs',
+            'kibana_discover_index_pattern_id': '620ad0e6-43df-4557-bda2-384960fa9086',
             'timestamp_field': 'timestamp',
             'name': 'test'
         },
         match={
-            'timestamp': '2019-09-01T00:30:00Z'
+            'timestamp': '2021-10-08T00:30:00Z'
         }
     )
-    assert url is None
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272021-10-08T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272021-10-08T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3A%27620ad0e6-43df-4557-bda2-384960fa9086%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
 
 
 def test_generate_kibana_discover_url_with_missing_kibana_discover_app_url():
@@ -155,15 +159,32 @@ def test_generate_kibana_discover_url_with_invalid_kibana_version():
     url = generate_kibana_discover_url(
         rule={
             'kibana_discover_app_url': 'http://kibana:5601/#/discover',
-            'kibana_discover_version': '4.5',
-            'kibana_discover_index_pattern_id': 'logs-*',
+            'kibana_discover_version': '0.0',
+            'kibana_discover_index_pattern_id': '620ad0e6-43df-4557-bda2-384960fa9086',
             'timestamp_field': 'timestamp'
         },
         match={
-            'timestamp': '2019-09-01T00:30:00Z'
+            'timestamp': '2021-10-08T00:30:00Z'
         }
     )
-    assert url is None
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272021-10-08T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272021-10-08T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28%29%2C'
+        + 'index%3A%27620ad0e6-43df-4557-bda2-384960fa9086%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
 
 
 def test_generate_kibana_discover_url_with_kibana_discover_app_url_env_substitution(environ):

--- a/tests/kibana_external_url_formatter_test.py
+++ b/tests/kibana_external_url_formatter_test.py
@@ -11,6 +11,7 @@ from elastalert.kibana_external_url_formatter import ShortKibanaExternalUrlForma
 from elastalert.kibana_external_url_formatter import append_security_tenant
 from elastalert.kibana_external_url_formatter import create_kibana_auth
 from elastalert.kibana_external_url_formatter import create_kibana_external_url_formatter
+from elastalert.kibana_external_url_formatter import is_kibana_atleastsevensixteen
 
 from elastalert.auth import RefeshableAWSRequestsAuth
 from elastalert.util import EAException
@@ -390,7 +391,7 @@ def test_create_kibana_external_url_formatter_with_shortening():
     assert formatter.auth == HTTPBasicAuth('john', 'doe')
     assert formatter.security_tenant == 'foo'
     assert formatter.goto_url == 'http://kibana.test.org/goto/'
-    assert formatter.shorten_url == 'http://kibana.test.org/api/shorten_url?security_tenant=foo'
+    assert formatter.shorten_url == 'http://kibana.test.org/api/short_url?security_tenant=foo'
 
 
 @pytest.mark.parametrize("test_case", [
@@ -498,3 +499,13 @@ def test_kibana_external_url_formatter_not_implemented():
     formatter = KibanaExternalUrlFormatter()
     with pytest.raises(NotImplementedError):
         formatter.format('test')
+
+
+def test_is_kibana_atleastsevensixteen():
+    assert is_kibana_atleastsevensixteen('7.16.0') is True
+    assert is_kibana_atleastsevensixteen('7.15.9') is False
+    assert is_kibana_atleastsevensixteen('8.0.0') is True
+    assert is_kibana_atleastsevensixteen('6.8.0') is False
+    assert is_kibana_atleastsevensixteen('') is True
+    assert is_kibana_atleastsevensixteen(None) is True
+    assert is_kibana_atleastsevensixteen('0.0') is True

--- a/tests/opensearch_discover_test.py
+++ b/tests/opensearch_discover_test.py
@@ -6,7 +6,10 @@ from elastalert.opensearch_discover import generate_opensearch_discover_url
 
 
 @pytest.mark.parametrize("opensearch_version", [
-    '2.11'
+    '2.11',
+    '3.0',
+    '0.0',
+    ' '
 ])
 def test_generate_opensearch_discover_url_with_relative_opensearch_discover_app_url(opensearch_version):
     url = generate_opensearch_discover_url(
@@ -20,7 +23,6 @@ def test_generate_opensearch_discover_url_with_relative_opensearch_discover_app_
             'timestamp': '2019-09-01T00:30:00Z'
         }
     )
-    print(url)
     expectedUrl = (
         'http://opensearch:5601/#/discover'
         + '?_g=%28'  # global start
@@ -77,7 +79,7 @@ def test_generate_opensearch_discover_url_with_missing_opensearch_discover_versi
     url = generate_opensearch_discover_url(
         rule={
             'opensearch_discover_app_url': 'http://opensearch:5601/#/discover',
-            'opensearch_discover_index_pattern_id': 'logs',
+            'opensearch_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timestamp_field': 'timestamp',
             'name': 'test'
         },
@@ -85,7 +87,25 @@ def test_generate_opensearch_discover_url_with_missing_opensearch_discover_versi
             'timestamp': '2019-09-01T00:30:00Z'
         }
     )
-    assert url is None
+    expectedUrl = (
+        'http://opensearch:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'discover%3A%28columns%3A%21%28_source%29%2C'
+        + 'isDirty%3A%21f%2Csort%3A%21%28%29%29%2C'
+        + 'metadata%3A%28indexPattern%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'view%3Adiscover%29%29'  # app end
+        + '&_q=%28filters%3A%21%28%29%2C'  # query and filter start
+        + 'query%3A%28language%3Alucene%2Cquery%3A%27%27%29%29'  # query and filter start
+    )
+    assert url == expectedUrl
 
 
 def test_generate_opensearch_discover_url_with_missing_opensearch_discover_app_url():
@@ -123,14 +143,32 @@ def test_generate_opensearch_discover_url_with_invalid_opensearch_version():
         rule={
             'opensearch_discover_app_url': 'http://opensearch:5601/#/discover',
             'opensearch_discover_version': '4.5',
-            'opensearch_discover_index_pattern_id': 'logs-*',
+            'opensearch_discover_index_pattern_id': 'd6cabfb6-aaef-44ea-89c5-600e9a76991a',
             'timestamp_field': 'timestamp'
         },
         match={
             'timestamp': '2019-09-01T00:30:00Z'
         }
     )
-    assert url is None
+    expectedUrl = (
+        'http://opensearch:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'discover%3A%28columns%3A%21%28_source%29%2C'
+        + 'isDirty%3A%21f%2Csort%3A%21%28%29%29%2C'
+        + 'metadata%3A%28indexPattern%3Ad6cabfb6-aaef-44ea-89c5-600e9a76991a%2C'
+        + 'view%3Adiscover%29%29'  # app end
+        + '&_q=%28filters%3A%21%28%29%2C'  # query and filter start
+        + 'query%3A%28language%3Alucene%2Cquery%3A%27%27%29%29'  # query and filter start
+    )
+    assert url == expectedUrl
 
 
 def test_generate_opensearch_discover_url_with_from_timedelta_and_timeframe():


### PR DESCRIPTION
## Description

Since there have been no notable differences in the Kibana API  as of  Elasticsearch 7.16, and since OpenSearch continues to work properly with discovery URLs even up to the latest major version (currently 3.1.0) I am removing the requirement to specify the Kibana or Opensearch version for the `generate_xxx_discovery_url` feature.

For clarity:

- I've confirmed that basic ElastAlert 2 operations supports Elasticsearch 9.0.3, including URL generation and URL shortening. 

- I've confirmed that basic ElastAlert 2 functionality supports OpenSearch 3.1.0, including URL generation (URL shortening is not available in OpenSearch).

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I will leave this PR open for a few days for the community to comment. If no objections are submitted it will be merged into master.