### PR TITLE
add compatible-mode for opensearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Other changes
 - Removed specific version requirement for Elastic Kibana and OpenSearch Discover - [#1682](https://github.com/jertel/elastalert2/pull/1682) - @jertel
 - If `--end` argument falls in the past then at least one full run cycle will now complete before exiting - [#1694](https://github.com/jertel/elastalert2/pull/1694) - @nkormakov
+- Add support for a `ES_VERSION` environment variable to override the Elasticsearch version - [#1690](https://github.com/jertel/elastalert2/pull/1690) - @fabian-heib
 
 # 2.25.0
 

--- a/docs/source/recipes/faq.rst
+++ b/docs/source/recipes/faq.rst
@@ -528,3 +528,10 @@ Yelp, the developer of the original elastalert, has the following article on its
 `ElastAlert: Alerting At Scale With Elasticsearch, Part 1 <https://engineeringblog.yelp.com/2015/10/elastalert-alerting-at-scale-with-elasticsearch.html>`_.
 
 `ElastAlert: Alerting At Scale With Elasticsearch, Part 2 <https://engineeringblog.yelp.com/2016/03/elastalert-part-two.html>`_.
+
+Can I force a specific Elasticsearch version?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Yes, you can override the detected cluster version by setting the `ES_VERSION` environment variable to your desired version (e.g. `ES_VERSION=8.2.0`).
+
+This is useful when using OpenSearch in “compatible-mode” or when automatic version detection fails.

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -564,6 +564,11 @@ def parse_hosts(host, port=9200):
 
 
 def get_version_from_cluster_info(client):
+    override_version = os.environ.get('ES_VERSION', None)
+    if override_version:
+        elastalert_logger.info('Using ES_VERSION environment variable: %s' % override_version)
+        return override_version
+
     esversion = None
     for retry in range(3):
         try:


### PR DESCRIPTION
## Description

Add compatible-mode for when opensearch is set with compatible-mode based on discussion #1507 

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

I can add documentation and changelog if this PR is something you want merged, about the unit test i'm not sure where it would put it, also the naming on the arg can be changed to something better. 
