### PR TITLE
Allow to run EA back in time with --end statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Other changes
 - Removed specific version requirement for Elastic Kibana and OpenSearch Discover - [#1682](https://github.com/jertel/elastalert2/pull/1682) - @jertel
-- `--end` command line argument now can be used to check rules back in time
+- If `--end` argument falls in the past then at least one full run cycle will now complete before exiting - [#1694](https://github.com/jertel/elastalert2/pull/1694) - @nkormakov
 
 # 2.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Other changes
 - Removed specific version requirement for Elastic Kibana and OpenSearch Discover - [#1682](https://github.com/jertel/elastalert2/pull/1682) - @jertel
+- `--end` command line argument now can be used to check rules back in time
 
 # 2.25.0
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1171,8 +1171,8 @@ class ElastAlerter(object):
 
                 next_run_dt = next_run.replace(tzinfo=datetime.timezone.utc)
                 if next_run_dt > endtime:
-                    elastalert_logger.info("End time '%s' falls before the next run time '%s', exiting." % (endtime, next_run_dt))
-                    exit(0)
+                    elastalert_logger.info("End time '%s' falls before the next run time '%s', all rules will be cheked once." % (endtime, next_run_dt))
+                    self.running = False
 
             if next_run < datetime.datetime.now(tz=datetime.UTC):
                 continue

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1171,7 +1171,7 @@ class ElastAlerter(object):
 
                 next_run_dt = next_run.replace(tzinfo=datetime.timezone.utc)
                 if next_run_dt > endtime:
-                    elastalert_logger.info("End time '%s' falls before the next run time '%s', all rules will be cheked once." % (endtime, next_run_dt))
+                    elastalert_logger.info("End time '%s' falls before the next run time '%s'; allowing a single run cycle to complete before exiting." % (endtime, next_run_dt))
                     self.running = False
 
             if next_run < datetime.datetime.now(tz=datetime.UTC):


### PR DESCRIPTION
## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->


### Issue observed
When running rules in debug on events in the past (for example `--start 2025-08-13T10:15:00+0300 --end 2025-08-13T11:00:00+0300`, elastalert exits prematurely because next run is later than the end boundary thus makes rules debugging a bit challenging, current workaround is to not use `--end` statement at all, but the drawback is that EA will plow through days of events until he reaches current time.

### Proposed solution
When end is behind utcnow(), do not exit the app - run it once more.
Behaviour can be limited to `--debug`, although I would've liked to have an opportunity to send real alerts with it.