### PR TITLE
Add support for loading custom Jinja2 filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- Add support for loading custom Jinja2 filters - [#1700](https://github.com/jertel/elastalert2/pull/1682) - @anroots-by
+- Add support for loading custom Jinja2 filters - [#1700](https://github.com/jertel/elastalert2/pull/1700) - @anroots-by
 
 ## Other changes
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 ## New features
-- None
+- Add support for loading custom Jinja2 filters - [#1700](https://github.com/jertel/elastalert2/pull/1682) - @anroots-by
 
 ## Other changes
 - None

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -10,3 +10,4 @@ ElastAlert 2 offers a variety of ways to extend the functionality. This includes
    recipes/adding_alerts
    recipes/adding_enhancements
    recipes/adding_loaders
+   recipes/adding_jinja_filters

--- a/docs/source/recipes/adding_jinja_filters.rst
+++ b/docs/source/recipes/adding_jinja_filters.rst
@@ -1,0 +1,72 @@
+.. _custom jinja2 filters:
+
+Custom Jinja2 Filters
+=====================
+
+`Jinja2 filters <https://jinja.palletsprojects.com/en/stable/api/#writing-filters>`_ are functions that allow you to modify variables in Jinja2 templates.
+ElastAlert 2 supports default Jinja2 filters out of the box, but you can also create your own custom filter functions and use them in alert templates.
+This is useful if you want to perform specific transformations that are not available in the built-in Jinja2 filters.
+
+To create a custom Jinja2 filter, you need to instruct ElastAlert to load it by specifying the ``jinja_filters`` option in your rule configuration file.
+
+.. code-block:: yaml
+
+    # rules/my-rule.yaml
+    jinja_filters:
+      - module.file.ClassName
+      - module.otherfile.OtherClassName
+
+The value of ``jinja_filters`` should be a list of strings, where each item specifies the module, file, and class name containing the filter functions.
+
+Example: ``filters.domain.DomainFilters`` would load the ``DomainFilters`` class from the ``domain.py`` file in the ``filters`` module (``filters/domain.py``).
+
+The module and class names can be arbitrary (but it needs to be on the load path). The class should contain one or more
+static methods that begin with `filter_`. Each of these methods will be registered as a Jinja2 filter, with the name being the method name without the `filter_` prefix.
+
+The loading of filters is global - any rule file can load a filter, and once loaded, the filter is available from all rules.
+Avoid loading race conditions by making sure any rule that depends on a custom filter also loads it.
+
+Example
+-------
+
+Let's create a custom filter that defangs links by replacing `.` (dot) with `[.]` in URL-s. First, create a modules folder for the filter in the ElastAlert 2 directory.
+
+.. code-block:: console
+
+    $ mkdir filters
+    $ cd filters
+    $ touch __init__.py
+
+Then, write the filter class. All methods starting with `filter_` will be registered as Jinja2 filters.
+
+.. code-block:: python
+
+    # filters/domain.py
+    class DomainFilters:
+
+        @staticmethod
+        def filter_defang(value):
+            """Replaces '.' with '[.]' in links to defang dangerous links."""
+            if not isinstance(value, str):
+                return value
+            return value.replace(".", "[.]")
+
+Now, let's load the filter and use it in an alert template.
+
+.. code-block:: yaml
+
+    # rules/link-rules.yaml
+    name: dangerous-link
+    type: any
+
+    filter:
+      - query:
+          query_string:
+            query: >
+              event.category:"dangerouse_network_activity"
+
+    jinja_filters:
+      - jinja.filters.Domain
+
+    alert_text: |
+      Found a dangerous URL from network logs: `{{ url.original | defang }}`

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -110,6 +110,8 @@ Rule Configuration Cheat Sheet
 +--------------------------------------------------------------+           |
 | ``match_enhancements`` (list of strs, no default)            |           |
 +--------------------------------------------------------------+           |
+| ``jinja_filters`` (list of strs, no default)                 |           |
++--------------------------------------------------------------+           |
 | ``top_count_number`` (int, default 5)                        |           |
 +--------------------------------------------------------------+           |
 | ``top_count_keys`` (list of strs)                            |           |
@@ -958,6 +960,12 @@ that will be given the match dictionary and can modify it before it is passed to
 is calculated and in the case of aggregated alerts, right before the alert is sent. This can be changed by setting ``run_enhancements_first``.
 The enhancements should be specified as
 ``module.file.EnhancementName``. See :ref:`Enhancements` for more information. (Optional, list of strings, no default)
+
+jinja_filters
+^^^^^^^^^^^^^^^^^^
+
+``jinja_filters``: A list of custom `Jinja2 filters <https://jinja.palletsprojects.com/en/stable/api/#writing-filters>`_ to load.
+The filters should be specified as ``module.file.ClassName``. See :ref:`Custom Jinja2 Filters` for more information. (Optional, list of strings, no default)
 
 run_enhancements_first
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -498,8 +498,7 @@ class RulesLoader(object):
 
                 self.jinja_environment.filters[filter_name] = filter_func
                 self.jinja_filters.append(filter_name)
-                
-        elastalert_logger.debug('Loaded custom Jinja2 filters are: %s', self.jinja_filters)
+                elastalert_logger.debug('Loaded custom Jinja2 filter: %s.%s', module_path, filter_name)
 
     def load_jinja_template(self, rule):
         if rule.get('alert_text_type') == 'alert_text_jinja':

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -307,6 +307,7 @@ properties:
   use_local_time: {type: boolean}
   custom_pretty_ts_format: {type: string}
   match_enhancements: {type: array, items: {type: string}}
+  jinja_filters: {type: array, items: {type: string}}
   query_key: *arrayOfString
   replace_dots_in_field_names: {type: boolean}
   scan_entire_timeframe: {type: boolean}

--- a/tests/jinja/filters.py
+++ b/tests/jinja/filters.py
@@ -1,0 +1,7 @@
+class DummyJinjaFilter:
+    """ Custom dummy Jinja2 filter class to test filter loading from a module """
+    @staticmethod
+    def filter_whisper(value):
+        if isinstance(value, str):
+            return value.lower()
+        return value

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -205,6 +205,21 @@ def test_load_inline_alert_rule_with_jinja():
         assert 'jinja_template' not in test_rule_copy['alert'][1].rule
 
 
+def test_load_jinja_filters():
+    rules_loader = FileRulesLoader(test_config)
+    test_rule_copy = copy.deepcopy(test_rule)
+
+    # Load a custom Jinja2 filter "yell"
+    test_rule_copy['jinja_filters'] = ['jinja.filters.DummyJinjaFilter']
+    test_rule_copy['alert_text_type'] = 'alert_text_jinja'
+    test_rule_copy['alert_text'] = 'WHATS YOUR {{ "NAME" | whisper }}?'
+
+    rules_loader.load_jinja_template(test_rule_copy)
+    output = test_rule_copy['jinja_template'].render()
+    print(output)
+    assert output == 'WHATS YOUR name?'
+
+
 def test_file_rules_loader_get_names_recursive():
     conf = {'scan_subdirectories': True, 'rules_folder': empty_folder_test_path}
     rules_loader = FileRulesLoader(conf)

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -209,14 +209,12 @@ def test_load_jinja_filters():
     rules_loader = FileRulesLoader(test_config)
     test_rule_copy = copy.deepcopy(test_rule)
 
-    # Load a custom Jinja2 filter "yell"
     test_rule_copy['jinja_filters'] = ['jinja.filters.DummyJinjaFilter']
     test_rule_copy['alert_text_type'] = 'alert_text_jinja'
     test_rule_copy['alert_text'] = 'WHATS YOUR {{ "NAME" | whisper }}?'
 
     rules_loader.load_jinja_template(test_rule_copy)
     output = test_rule_copy['jinja_template'].render()
-    print(output)
     assert output == 'WHATS YOUR name?'
 
 


### PR DESCRIPTION
## Description

Introduce a new rule option for loading custom jinja2 filters. Custom filters enable to expand the template capabilities of Jinja templates with custom transformations and lookups for passed fields.
 
The loading logic is similar to match_enhancements.

Change how rendering of jinja2 templates is done: use an already configured jinja2 Environment, instead of an empty Template object. This is needed to support loaded filters.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

