### PR TITLE
Fix percentile metric_aggregation rule error for rules with compound query keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 ## Other changes
-- None
+- Fix percentile metric_aggregation rule error for rules with compound query keys - [#1701](https://github.com/jertel/elastalert2/pull/1701) - @jhatcher1
 
 # 2.26.0
 

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -1072,8 +1072,9 @@ class MetricAggregationRule(BaseAggregationRule):
 
         self.metric_key = 'metric_' + self.rules['metric_agg_key'] + '_' + self.rules['metric_agg_type']
 
-        if not self.rules['metric_agg_type'] in self.allowed_aggregations.union(self.allowed_percent_aggregations):
-            raise EAException("metric_agg_type must be one of %s" % (str(self.allowed_aggregations)))
+        all_allowed_aggregations = self.allowed_aggregations.union(self.allowed_percent_aggregations)
+        if not self.rules['metric_agg_type'] in all_allowed_aggregations:
+            raise EAException("metric_agg_type must be one of %s" % (str(all_allowed_aggregations)))
         if self.rules['metric_agg_type'] in self.allowed_percent_aggregations and self.rules['percentile_range'] is None:
             raise EAException("percentile_range must be specified for percentiles aggregation")
 
@@ -1137,7 +1138,10 @@ class MetricAggregationRule(BaseAggregationRule):
             if 'interval_aggs' in aggregation_data:
                 metric_val_arr = [term[self.metric_key]['value'] for term in aggregation_data['interval_aggs']['buckets']]
             else:
-                metric_val_arr = [aggregation_data[self.metric_key]['value']]
+                if self.rules['metric_agg_type'] in self.allowed_percent_aggregations:
+                    metric_val_arr = list(aggregation_data[self.metric_key]['values'].values())
+                else:
+                    metric_val_arr = [aggregation_data[self.metric_key]['value']]
             for metric_val in metric_val_arr:
                 if self.crossed_thresholds(metric_val):
                     match_data[self.rules['timestamp_field']] = timestamp


### PR DESCRIPTION
## Description

This PR fixes metric_aggregation rules of type `percentile`, when used with a compound query key.

Prior to this fix, using such a rule would raise the following `KeyError`:
```
ERROR:elastalert:Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/elastalert/elastalert.py", line 1277, in handle_rule_execution
    num_matches = self.run_rule(rule, endtime, rule.get('initial_starttime'))
  File "/usr/local/lib/python3.13/site-packages/elastalert/elastalert.py", line 900, in run_rule
    if not self.run_query(rule, tmp_endtime, endtime):
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/elastalert.py", line 654, in run_query
    rule_inst.add_aggregation_data(data)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 1041, in add_aggregation_data
    self.unwrap_term_buckets(timestamp, payload_data['bucket_aggs']['buckets'])
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 1055, in unwrap_term_buckets
    self.check_matches(timestamp, term_data['key'], term_data)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 1103, in check_matches
    self.check_matches_recursive(timestamp, query_key, aggregation_data, self.rules['compound_query_key'], dict())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 1131, in check_matches_recursive
    self.check_matches_recursive(timestamp,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
                                 query_key,
                                 ^^^^^^^^^^
                                 result,
                                 ^^^^^^^
                                 compound_keys[1:],
                                 ^^^^^^^^^^^^^^^^^^
                                 match_data)
                                 ^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/elastalert/ruletypes.py", line 1140, in check_matches_recursive
    metric_val_arr = [aggregation_data[self.metric_key]['value']]
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'value'
```

I was able to reproduce this issue with the following minimal example:

1. Insert some documents to a local elasticsearch cluster:
```
  curl -X POST "http://localhost:9200/logstash-test/_bulk" \
    -H 'Content-Type: application/json' \
    -d '
  { "index": { "_index": "logstash-test" } }
  { "environment": "production", "kubernetes": { "pod_name": "example-pod" }, "query_state": "complete", "region": "europe", "message": "Query complete: took 225ms", "query_elapsed_ms": 225, "@timestamp": "2025-09-12T10:21:36.831Z" }
  { "index": { "_index": "logstash-test" } }
  { "environment": "staging", "kubernetes": { "pod_name": "example-pod" }, "query_state": "complete", "region": "europe", "message": "Query complete: took 225ms", "query_elapsed_ms": 225, "@timestamp": "2025-09-12T10:21:36.831Z" }
  { "index": { "_index": "logstash-test" } }
  { "environment": "production", "kubernetes": { "pod_name": "example-pod" }, "query_state": "complete", "region": "US", "message": "Query complete: took 225ms", "query_elapsed_ms": 225, "@timestamp": "2025-09-12T10:21:36.831Z" }
  '
  ```

2. Create a file `rule.yaml`
  ```
  name: High query time rule
  type: metric_aggregation
  index: logstash-*

  metric_agg_key: query_elapsed_ms
  metric_agg_type: percentiles
  percentile_range: 90

  timeframe:
    minutes: 5

  filter:
    - query:
        query_string:
          query: |
            (kubernetes.pod_name:"example-pod")
            AND (query_state:"complete")

  alert:
    - "debug"

  max_threshold: 1
  
  query_key:
    - environment.keyword
    - region.keyword
  ```

3. Test the rule with `elastalert-test-rule rule.yaml --days 10`
4. The `KeyError` is observed without the fix, and alerts are fired as expected with the fix applied.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
