### PR TITLE
Support dict form for summary_table_fields with custom column headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## New features
 - [Datadog] Add optional `datadog_api_url` parameter to support regional Datadog sites (US3, US5, EU1, AP1, etc.) - [#1754](https://github.com/jertel/elastalert2/pull/1754) - @BillyWeans
+- `summary_table_fields` now accepts a dict form with `path` and optional `header` keys for custom column labels - [#PR_NUMBER](https://github.com/jertel/elastalert2/pull/PR_NUMBER) - @dennis-trapp
 
 ## Other changes
 - Replace `es.delete()` with `delete_by_query()` in aggregation cleanup to support Elasticsearch data streams as the writeback index - [#1755](https://github.com/jertel/elastalert2/pull/1755) - @peterlehot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## New features
 - [Datadog] Add optional `datadog_api_url` parameter to support regional Datadog sites (US3, US5, EU1, AP1, etc.) - [#1754](https://github.com/jertel/elastalert2/pull/1754) - @BillyWeans
-- `summary_table_fields` now accepts a dict form with `path` and optional `header` keys for custom column labels - [#PR_NUMBER](https://github.com/jertel/elastalert2/pull/PR_NUMBER) - @dennis-trapp
+- `summary_table_fields` now accepts a dict form with `path` and optional `header` keys for custom column labels - [#1763](https://github.com/jertel/elastalert2/pull/1763) - @dennis-trapp
 
 ## Other changes
 - Replace `es.delete()` with `delete_by_query()` in aggregation cleanup to support Elasticsearch data streams as the writeback index - [#1755](https://github.com/jertel/elastalert2/pull/1755) - @peterlehot

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -511,6 +511,16 @@ Then, for the same sample data shown above listing alice and bob's events, Elast
     |      alice       |   something else   |
     +------------------+--------------------+
 
+Each entry may instead be a dict with a ``path`` (the field to look up) and an optional ``header`` (the column heading to display). If ``header`` is omitted, ``path`` is used as the heading. String and dict entries can be mixed in the same list. For example::
+
+    summary_table_fields:
+        - path: my_data.username
+          header: User
+        - path: my_data.event_type
+          header: Event
+
+would render with ``User`` and ``Event`` as column headings while still looking up values from ``my_data.username`` and ``my_data.event_type``.
+
 
 .. note::
    By default, aggregation time is relative to the current system time, not the time of the match. This means that running ElastAlert 2 over
@@ -993,7 +1003,7 @@ aggregation_key
 summary_table_fields
 ^^^^^^^^^^^^^^^^^^^^
 
-``summary_table_fields``: Specifying the summmary_table_fields in conjunction with an aggregation will make it so that each aggregated alert will contain a table summarizing the values for the specified fields in all the matches that were aggregated together.
+``summary_table_fields``: Specifying the summmary_table_fields in conjunction with an aggregation will make it so that each aggregated alert will contain a table summarizing the values for the specified fields in all the matches that were aggregated together. Each entry may be a string field path, or a dict of the form ``{path: <field>, header: <column label>}`` to override the rendered column heading; ``header`` defaults to ``path`` when omitted. See the prose section above for an example.
 
 summary_table_type
 ^^^^^^^^^^^^^^^^^^^^

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -256,10 +256,25 @@ class Alerter(object):
             if not isinstance(summary_table_fields, list):
                 summary_table_fields = [summary_table_fields]
 
+            # Each entry is either a string field path, or a dict with required 'path' and optional 'header'.
+            # Split into parallel lists so paths drive lookups/logging while headers drive rendered column names.
+            summary_table_paths = []
+            summary_table_headers = []
+            for entry in summary_table_fields:
+                if isinstance(entry, dict):
+                    path = entry['path']
+                    header = entry.get('header', path)
+                else:
+                    path = entry
+                    header = entry
+                summary_table_paths.append(path)
+                summary_table_headers.append(header)
+
             # Include a count aggregation so that we can see at a glance how many of each aggregation_key were encountered
-            summary_table_fields_with_count = summary_table_fields + ['count']
+            summary_table_paths_with_count = summary_table_paths + ['count']
+            summary_table_headers_with_count = summary_table_headers + ['count']
             text += "Aggregation resulted in the following data for summary_table_fields ==> {0}:\n\n".format(
-                summary_table_fields_with_count
+                summary_table_paths_with_count
             )
 
             # Prepare match_aggregation used in both table types
@@ -267,7 +282,7 @@ class Alerter(object):
 
             # Maintain an aggregate count for each unique key encountered in the aggregation period
             for match in matches:
-                key_tuple = tuple([str(lookup_es_key(match, key)) for key in summary_table_fields])
+                key_tuple = tuple([str(lookup_es_key(match, key)) for key in summary_table_paths])
                 if key_tuple not in match_aggregation:
                     match_aggregation[key_tuple] = 1
                 else:
@@ -281,9 +296,9 @@ class Alerter(object):
             # Type dependent table style
             if summary_table_type == 'ascii':
                 text_table = Texttable(max_width=self.get_aggregation_summary_text__maximum_width())
-                text_table.header(summary_table_fields_with_count)
+                text_table.header(summary_table_headers_with_count)
                 # Format all fields as 'text' to avoid long numbers being shown as scientific notation
-                text_table.set_cols_dtype(['t' for i in summary_table_fields_with_count])
+                text_table.set_cols_dtype(['t' for i in summary_table_headers_with_count])
 
                 for keys, count in match_aggregation.items():
                     text_table.add_row([key for key in keys] + [count])
@@ -292,9 +307,9 @@ class Alerter(object):
             elif summary_table_type == 'markdown':
                 # Adapted from https://github.com/codazoda/tomark/blob/master/tomark/tomark.py
                 # Create table header
-                text += '| ' + ' | '.join(map(str, summary_table_fields_with_count)) + ' |\n'
+                text += '| ' + ' | '.join(map(str, summary_table_headers_with_count)) + ' |\n'
                 # Create header separator
-                text += '|-----' * len(summary_table_fields_with_count) + '|\n'
+                text += '|-----' * len(summary_table_headers_with_count) + '|\n'
                 # Create table row
                 for keys, count in match_aggregation.items():
                     markdown_row = ""
@@ -302,12 +317,12 @@ class Alerter(object):
                         markdown_row += '| ' + str(key) + ' '
                     text += markdown_row + '| ' + str(count) + ' |\n'
                 text += '\n'
-            
+
             elif summary_table_type == 'html':
                 # Portions of the following block of HTML formatting code was taken from
                 # an abandoned PR (https://github.com/jertel/elastalert2/pull/1227).
                 text_table = PrettyTable()
-                text_table.field_names = summary_table_fields_with_count
+                text_table.field_names = summary_table_headers_with_count
                 text_table.set_style(TableStyle.MSWORD_FRIENDLY)
                 text_table.border = True
                 text_table.header = True

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -308,7 +308,17 @@ properties:
   notify_all_errors: {type: boolean}
 
   ### summary table
-  summary_table_fields: {type: array, items: {type: string}}
+  summary_table_fields:
+    type: array
+    items:
+      oneOf:
+        - type: string
+        - type: object
+          additionalProperties: false
+          required: [path]
+          properties:
+            path: {type: string, minLength: 1}
+            header: {type: string}
   summary_table_type: {type: string, enum: ['ascii', 'html', 'markdown']}
   summary_table_max_rows: {type: integer, minimum: 0}
   summary_prefix: {type: string}

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -354,6 +354,91 @@ def test_alert_aggregation_summary_table_suffix_prefix():
     assert "This is the suffix" in summary_table
 
 
+def test_alert_aggregation_summary_dict_form_with_headers():
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'A very long subject',
+        'aggregation': 1,
+        'summary_table_fields': [
+            {'path': 'field', 'header': 'Hostname'},
+            {'path': 'abc', 'header': 'Avg shard size (GB)'},
+        ],
+        'summary_table_type': 'markdown'
+    }
+    matches = [
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+    ]
+    alert = Alerter(rule)
+    summary_table = str(alert.get_aggregation_summary_text(matches))
+    # Custom headers are used in the rendered header row
+    assert "| Hostname | Avg shard size (GB) | count |" in summary_table
+    # Paths still drive value lookup, so the data rows contain the looked-up values
+    assert "| field_value | abc from match | 3 |" in summary_table
+    assert "| field_value | cde from match | 2 |" in summary_table
+    # Field paths should not appear as column headings when headers are provided
+    assert "| field | abc | count |" not in summary_table
+
+
+def test_alert_aggregation_summary_dict_form_header_omitted():
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'A very long subject',
+        'aggregation': 1,
+        'summary_table_fields': [
+            {'path': 'field'},
+            {'path': 'abc'},
+        ],
+        'summary_table_type': 'markdown'
+    }
+    matches = [
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+    ]
+    alert = Alerter(rule)
+    summary_table = str(alert.get_aggregation_summary_text(matches))
+    # Header defaults to path when omitted
+    assert "| field | abc | count |" in summary_table
+    assert "| field_value | abc from match | 1 |" in summary_table
+    assert "| field_value | cde from match | 1 |" in summary_table
+
+
+def test_alert_aggregation_summary_mixed_string_and_dict_forms():
+    rule = {
+        'name': 'test_rule',
+        'type': mock_rule(),
+        'owner': 'the_owner',
+        'priority': 2,
+        'alert_subject': 'A very long subject',
+        'aggregation': 1,
+        'summary_table_fields': [
+            'field',
+            {'path': 'abc', 'header': 'Custom abc'},
+        ],
+        'summary_table_type': 'markdown'
+    }
+    matches = [
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'abc from match', },
+        {'@timestamp': '2016-01-01', 'field': 'field_value', 'abc': 'cde from match', },
+    ]
+    alert = Alerter(rule)
+    summary_table = str(alert.get_aggregation_summary_text(matches))
+    # String entry keeps its path as header; dict entry uses its custom header
+    assert "| field | Custom abc | count |" in summary_table
+    assert "| field_value | abc from match | 2 |" in summary_table
+    assert "| field_value | cde from match | 1 |" in summary_table
+
+
 def test_alert_subject_size_limit_with_args(ea):
     rule = {
         'name': 'test_rule',

--- a/tests/loaders_test.py
+++ b/tests/loaders_test.py
@@ -728,3 +728,26 @@ def test_load_yaml_imports_modified():
 def test_load_rule_schema():
     validator = load_rule_schema()
     validator.check_schema(validator.schema)
+
+
+def test_summary_table_fields_schema():
+    validator = load_rule_schema()
+    base_rule = {'type': 'any', 'index': 'test', 'alert': 'debug'}
+
+    def errors_for(value):
+        rule = dict(base_rule, summary_table_fields=value)
+        return [e for e in validator.iter_errors(rule)
+                if 'summary_table_fields' in list(e.absolute_path)]
+
+    # Valid: original string-form list
+    assert errors_for(['host.hostname', 'metric_agg_value_formatted']) == []
+    # Valid: dict-form with both path and header
+    assert errors_for([{'path': 'host.hostname', 'header': 'Hostname'}]) == []
+    # Valid: dict-form with header omitted
+    assert errors_for([{'path': 'host.hostname'}]) == []
+    # Valid: mixed string and dict entries
+    assert errors_for(['host.hostname', {'path': 'metric_agg_value_formatted', 'header': 'Avg'}]) == []
+    # Invalid: dict missing required 'path'
+    assert errors_for([{'header': 'Hostname'}]) != []
+    # Invalid: dict with unknown property
+    assert errors_for([{'path': 'host.hostname', 'foo': 'bar'}]) != []


### PR DESCRIPTION
Each entry in summary_table_fields can now be either a string field path (existing behavior) or a dict {path, header?} where header overrides the rendered column heading. If header is omitted it defaults to path. String and dict entries can be mixed in the same list.

Lookups via lookup_es_key and the debug log line continue to use field paths so debugging output stays meaningful; only the rendered column labels (ascii/markdown/html) pick up the custom headers.

## Description

<!--
Provide a description for your pull request. Note any breaking changes.
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
