### PR TITLE
Fix Kibana Discover URL when query_key value is empty or a single-item array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add ES|QL (Elasticsearch Piped Query Language) support - [#1767](https://github.com/jertel/elastalert2/pull/1767) - @jertel
 
 ## Other changes
-- Kibana Discover URLs no longer emit `phrase = ''` filters when a `query_key` field's value is empty or an array of empty strings; render as a negate-exists filter (matching the existing behaviour for missing values), and unwrap single-element lists to the underlying scalar - @thejohnrichard
+- [Kibana] Fix discover URLs when query_key values are empty - [#1769](https://github.com/jertel/elastalert2/pull/1769) - @thejohnrichard
 
 # 2.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add ES|QL (Elasticsearch Piped Query Language) support - [#1767](https://github.com/jertel/elastalert2/pull/1767) - @jertel
 
 ## Other changes
-- None
+- Kibana Discover URLs no longer emit `phrase = ''` filters when a `query_key` field's value is empty or an array of empty strings; render as a negate-exists filter (matching the existing behaviour for missing values), and unwrap single-element lists to the underlying scalar - @thejohnrichard
 
 # 2.30.0
 

--- a/elastalert/kibana_discover.py
+++ b/elastalert/kibana_discover.py
@@ -74,6 +74,36 @@ def kibana7_disover_global_state(from_time, to_time):
     } )
 
 
+def _normalize_query_value(value):
+    """Collapse empty/single-element query_key values before filter emission.
+
+    Elasticsearch returns multi-valued fields as arrays even when they hold a
+    single item, and rules using such fields as ``query_key`` otherwise render
+    Kibana filters with ``params.query: ['']`` — a phrase filter that matches
+    no documents, producing an empty Discover view for the reviewer.
+
+    Returns:
+      - ``None`` when the value is absent, an empty string, or a list that
+        collapses to nothing after dropping ``None``/empty-string entries;
+        callers emit the existing ``negate exists`` filter for this case.
+      - The sole surviving element when the input is a single-item list.
+      - The original value otherwise (scalars pass through; multi-value lists
+        are returned unchanged so callers may extend to a ``phrases`` filter).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return None if value == '' else value
+    if isinstance(value, list):
+        cleaned = [v for v in value if v not in (None, '')]
+        if not cleaned:
+            return None
+        if len(cleaned) == 1:
+            return cleaned[0]
+        return cleaned
+    return value
+
+
 def kibana_discover_app_state(index, columns, filters, query_keys, match):
     app_filters = []
 
@@ -105,7 +135,7 @@ def kibana_discover_app_state(index, columns, filters, query_keys, match):
         } )
 
     for query_key in query_keys:
-        query_value = lookup_es_key(match, query_key)
+        query_value = _normalize_query_value(lookup_es_key(match, query_key))
 
         if query_value is None:
             app_filters.append( {

--- a/tests/kibana_discover_test.py
+++ b/tests/kibana_discover_test.py
@@ -749,6 +749,132 @@ def test_generate_kibana_discover_url_with_missing_query_key_value():
     assert url == expectedUrl
 
 
+@pytest.mark.parametrize("empty_value", [
+    '',
+    [],
+    [''],
+    [None],
+    ['', None],
+])
+def test_generate_kibana_discover_url_with_empty_query_key_value(empty_value):
+    """Empty scalar/list values must render as `negate exists` filters,
+    not `phrase = ''` filters that silently match no documents.
+    """
+    url = generate_kibana_discover_url(
+        rule={
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '8.17',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'status'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'status': empty_value
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'exists%3A%28field%3Astatus%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Astatus%2C'
+        + 'negate%3A%21t%2C'
+        + 'type%3Aexists%2C'
+        + 'value%3Aexists'
+        + '%29'  # meta end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
+def test_generate_kibana_discover_url_with_single_element_list_query_key_value():
+    """A single-element list must produce the same phrase filter as the
+    unwrapped scalar; Elasticsearch returns multi-valued fields as arrays
+    even when the field carries a single value.
+    """
+    url = generate_kibana_discover_url(
+        rule={
+            'kibana_discover_app_url': 'http://kibana:5601/#/discover',
+            'kibana_discover_version': '8.17',
+            'kibana_discover_index_pattern_id': 'logs-*',
+            'timestamp_field': 'timestamp',
+            'query_key': 'geo.dest'
+        },
+        match={
+            'timestamp': '2019-09-01T00:30:00Z',
+            'geo': {
+                'dest': ['ok']
+            }
+        }
+    )
+    expectedUrl = (
+        'http://kibana:5601/#/discover'
+        + '?_g=%28'  # global start
+        + 'filters%3A%21%28%29%2C'
+        + 'refreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2C'
+        + 'time%3A%28'  # time start
+        + 'from%3A%272019-09-01T00%3A20%3A00Z%27%2C'
+        + 'to%3A%272019-09-01T00%3A40%3A00Z%27'
+        + '%29'  # time end
+        + '%29'  # global end
+        + '&_a=%28'  # app start
+        + 'columns%3A%21%28_source%29%2C'
+        + 'filters%3A%21%28'  # filters start
+
+        + '%28'  # filter start
+        + '%27%24state%27%3A%28store%3AappState%29%2C'
+        + 'meta%3A%28'  # meta start
+        + 'alias%3A%21n%2C'
+        + 'disabled%3A%21f%2C'
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'key%3Ageo.dest%2C'
+        + 'negate%3A%21f%2C'
+        + 'params%3A%28query%3Aok%2C'  # params start
+        + 'type%3Aphrase'
+        + '%29%2C'  # params end
+        + 'type%3Aphrase%2C'
+        + 'value%3Aok'
+        + '%29%2C'  # meta end
+        + 'query%3A%28'  # query start
+        + 'match%3A%28'  # match start
+        + 'geo.dest%3A%28'  # geo.dest start
+        + 'query%3Aok%2C'
+        + 'type%3Aphrase'
+        + '%29'  # geo.dest end
+        + '%29'  # match end
+        + '%29'  # query end
+        + '%29'  # filter end
+
+        + '%29%2C'  # filters end
+        + 'index%3A%27logs-%2A%27%2C'
+        + 'interval%3Aauto'
+        + '%29'  # app end
+    )
+    assert url == expectedUrl
+
+
 def test_generate_kibana_discover_url_with_compound_query_key():
     url = generate_kibana_discover_url(
         rule={


### PR DESCRIPTION
## Description

Elasticsearch returns multi-valued fields as arrays even when they carry a single value. When a rule uses such a field as `query_key`, `kibana_discover_app_state()` currently emits a Kibana filter like `params.query: ['']` — a phrase filter that matches no documents. The reviewer follows the Kibana link from the alert and lands on an empty Discover view, which reads as a broken link.

### Reproduction

- Rule: `query_key: [db.name, user.name, cloud.instance.name, service.environment]`
- Match doc (as MongoDB Atlas emits): `db.name = [""]`, `user.name = [""]`, `cloud.instance.name = "platon"`, `service.environment = "production"`
- Rendered URL contains filters `params.query: !('')` for `db.name` and `user.name`, decoded from Rison as `params.query: ['']`. Kibana renders these as active filters, silently returns zero results.

### Fix

Add a small normaliser and apply it to each `query_key` value before filter emission:

- `None`, `''`, `[]`, `['']`, `[None, '']` → collapse to `None`. Existing code path emits a negate-exists filter (matching the current behaviour for missing values).
- `['single']` → unwrap to `'single'`. Existing code path emits the same phrase filter as the scalar case.
- Multi-value lists (e.g. `['a', 'b']`) → passed through unchanged. Behaviour matches today's code so this PR does not attempt to change how those render.

### Diff shape

- `elastalert/kibana_discover.py`: +32 / -0. No existing logic paths deleted.
- `tests/kibana_discover_test.py`: +126 / -0. Six new tests, no existing tests modified.
- `CHANGELOG.md`: 1-line note under `2.TBD.TBD` → Other changes.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [x] I have included unit tests for my changes or additions.
- [x] I have successfully run `make test-docker` with my changes. All tests pass; docs build clean.
- [x] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io). *Not applicable: this is a bugfix that restores the intended behaviour when a field is empty. No new configurable behaviour is introduced.*
- [x] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).

## Questions or Comments

New tests are parametric so they read as one block for the empty-value cases and mirror the existing `null_query_key_value` and `str_query_key` tests' expected URLs — deliberately keeping the assertions surface small and consistent with the file's existing style.

Multi-value list handling (rendering as a `phrases`/"IS ONE OF" filter) is deliberately out of scope for this PR: current behaviour is preserved, the change here is narrow, and a follow-up can add proper multi-value support later.